### PR TITLE
feat(auth-jwt), fix|docs(charts): Security Assessment

### DIFF
--- a/charts/agent-connector-azure-vault/Chart.yaml
+++ b/charts/agent-connector-azure-vault/Chart.yaml
@@ -25,8 +25,9 @@
 apiVersion: v2
 name: agent-connector-azure-vault
 description: |
-  A Helm chart for an Agent-Enabled Tractus-X Eclipse Data Space Connector. The connector deployment consists of two runtime consists of a
-  Control Plane and a Data Plane. Note that _no_ external dependencies such as a PostgreSQL database and Azure KeyVault are included.
+  A Helm chart for an Agent-Enabled Tractus-X Eclipse Data Space Connector configured against Azure Vault. This is a variant of [the Tractus-X Azure Vault Connector Helm Chart](https://github.com/eclipse-tractusx/tractusx-edc/tree/main/charts/tractusx-connector-azure-vault) which allows 
+  to deal with several data (and agent) planes. The connector deployment consists of at least two runtime consists of a
+  Control Plane and one or several Data Planes. Note that _no_ external dependencies such as a PostgreSQL database and Azure KeyVault are included.
 
   This chart is intended for use with an _existing_ PostgreSQL database and an _existing_ Azure KeyVault.
 # A chart can be either an 'application' or a 'library' chart.
@@ -41,7 +42,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.9.6-SNAPSHOT
+version: 1.9.7-SNAPSHOT
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/agent-connector-azure-vault/Chart.yaml
+++ b/charts/agent-connector-azure-vault/Chart.yaml
@@ -25,7 +25,7 @@
 apiVersion: v2
 name: agent-connector-azure-vault
 description: |
-  A Helm chart for an Agent-Enabled Tractus-X Eclipse Data Space Connector configured against Azure Vault. This is a variant of [the Tractus-X Azure Vault Connector Helm Chart](https://github.com/eclipse-tractusx/tractusx-edc/tree/main/charts/tractusx-connector-azure-vault) which allows 
+  A Helm chart for an Agent-Enabled Tractus-X Eclipse Data Space Connector configured against Azure Vault. This is a variant of [the Tractus-X Azure Vault Connector Helm Chart](https://github.com/eclipse-tractusx/tractusx-edc/tree/main/charts/tractusx-connector-azure-vault) which allows
   to deal with several data (and agent) planes. The connector deployment consists of at least two runtime consists of a
   Control Plane and one or several Data Planes. Note that _no_ external dependencies such as a PostgreSQL database and Azure KeyVault are included.
 

--- a/charts/agent-connector-azure-vault/README.md
+++ b/charts/agent-connector-azure-vault/README.md
@@ -22,12 +22,29 @@
 
 ![Version: 1.9.7-SNAPSHOT](https://img.shields.io/badge/Version-1.9.7--SNAPSHOT-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.9.5-SNAPSHOT](https://img.shields.io/badge/AppVersion-1.9.5--SNAPSHOT-informational?style=flat-square)
 
-A Helm chart for an Agent-Enabled Tractus-X Eclipse Data Space Connector. The connector deployment consists of two runtime consists of a
-Control Plane and a Data Plane. Note that _no_ external dependencies such as a PostgreSQL database and Azure KeyVault are included.
+A Helm chart for an Agent-Enabled Tractus-X Eclipse Data Space Connector configured against Azure Vault. This is a variant of [the Tractus-X Azure Vault Connector Helm Chart](https://github.com/eclipse-tractusx/tractusx-edc/tree/main/charts/tractusx-connector-azure-vault) which allows
+to deal with several data (and agent) planes. The connector deployment consists of at least two runtime consists of a
+Control Plane and one or several Data Planes. Note that _no_ external dependencies such as a PostgreSQL database and Azure KeyVault are included.
 
 This chart is intended for use with an _existing_ PostgreSQL database and an _existing_ Azure KeyVault.
 
 **Homepage:** <https://github.com/eclipse-tractusx/knowledge-agents-edc/>
+
+## Setting up your BPNL and the Control Plane's Management API Key
+
+The secure API-Key that is shared between control and agent plane is configured in the following property:
+- 'controlplane.endpoints.management.authKey': Cleartext API Key as used to secure the control planes management api (and is used by the agent plane to synchronize assets and negotiate calls).
+
+You should set your BPNL in the folloing property:
+- 'participant.id': 'BPNL' followed by 12 alphanumerical characters as handed out to you during onboarding.
+
+## Setting up Azure Vault
+
+You should set your BPNL in the folloing property:
+- 'vault.azure.name': Name of the vault
+- 'vault.azure.client': Id of the registered application that this EDC represents
+- 'vault.azure.tenant': Id of the subscription that the vault runs into
+- 'vault.azure.secret' or 'vault.azure.certificate': the secret/credential to use when interacting with Azure Vault
 
 ## Setting up SSI
 
@@ -56,6 +73,21 @@ Be sure to provide the following configuration entries to your Tractus-X EDC Hel
 - `controlplane.ssi.oauth.tokenurl`: the URL (of KeyCloak), where access tokens can be obtained
 - `controlplane.ssi.oauth.client.id`: client ID for KeyCloak
 - `controlplane.ssi.oauth.client.secretAlias`: the alias under which the client secret is stored in the vault. Defaults to `client-secret`.
+
+## Setting up the Agent Planes
+
+Make sure to adapt the Agent Plane's application-facing endpoint security:
+- 'dataplanes.agentplane.auth.default.type': The type of authentication service to use (defaults to api-key, you could also use jwt)
+- 'dataplanes.agentplane.auth.default.apiCode': If type is api-key, this is the hash of the accepted api key
+- 'dataplanes.agentplane.auth.default.vaultKey': If type is api-key, this is the key where the api key can be retrieved from the configured vault
+- 'dataplanes.agentplane.auth.default.publicKey': If type is jwt, this is a url where the public key to verify token with can be found
+- 'dataplanes.agentplane.auth.default.checkExpiry': If type is jwt, determines whether token expiry is checked (default: true)
+
+Be sure to review the Agent Plane's service delegation filter which regulates with which external Agent's (SERVICE) this instance may interact. These properties form typical allow/deny conditions. Because of the nature of SPARQL, interacting with such a service may not only mean to import data from there, but you must take into account bound variables in the SERVICE contexts are also exported to there. So you should be rather prohibitive here. 
+- 'dataplanes.agentplane.agent.services.allow': A regular expression of allowed Agent/Sparql SERVICE contexts in the default graph (federated data catalogue). The default graph only contains meta-data and can only be invoked by any in-house application, so usually you can be a bit more relaxed on this level. For example, you might be tempted to allow to mix your application logic and data with some universal service, such as Wikidata.
+- 'dataplanes.agentplane.agent.services.deny': A regular expression of denied outgoing Agent/Sparql SERVICE contexts in the default graph (federated data catalogue). Typically you would restrict any unsecured http call by this properties.
+- 'dataplanes.agentplane.agent.services.assets.allow': A regular expression of allowed Agent/Sparql SERVICE contexts when inside a data graph/asset (unless there are more specific settings in the asset itself). Since this affects how you can spice up your business data, you would only allow connections to trusted business partners connectors.
+- 'dataplanes.agentplane.agent.services.assets.deny': A regular expression of denied Agent/Sparql SERVICE contexts. Use this to filter out unsecure protocols such as edc and http as well as to implement blacklists.
 
 Be sure to adapt the agent configuration
 - 'dataplanes.agentplane.configs.dataspace.ttl': additional TTL text resource which lists the partner BPNs and their associated connectors.
@@ -210,15 +242,15 @@ helm install my-release eclipse-tractusx/agent-connector-azure-vault --version 1
 | dataplanes.dataplane.agent.services.deny | string | `"http://.*"` | A regular expression which outgoing service URLs must not match (unless overwritten by a specific asset property) |
 | dataplanes.dataplane.agent.skillcontract | string | `"Contract?partner=Skill"` | Names the visible contract under which new skills are published (if not otherwise specified) |
 | dataplanes.dataplane.agent.synchronization | int | `-1` | The synchronization interval in ms to update the federated data catalogue |
-| dataplanes.dataplane.auth | object | `{"default":{"api-code":69609650,"check-expiry":true,"context":"default","public-key":null,"register":false,"type":"api-key","vault-key":null}}` | Data Plane Authentication using the KA-EDC-AUTH-JWT extension, any entry has a type (api-key, jwt or composite) and a (set of) path contexts (see endpoints) followed by type-specific entries |
-| dataplanes.dataplane.auth.default | object | `{"api-code":69609650,"check-expiry":true,"context":"default","public-key":null,"register":false,"type":"api-key","vault-key":null}` | the default authentication service |
-| dataplanes.dataplane.auth.default.api-code | int | `69609650` | specific api-code associated to the default api-key 'Hello', Change this when type=api-key or use the vault-key property instead |
-| dataplanes.dataplane.auth.default.check-expiry | bool | `true` | controls whether the expiry date of jwt tokens is checked when type=jwt |
+| dataplanes.dataplane.auth | object | `{"default":{"apiCode":"69609650","checkExpiry":true,"context":"default","publicKey":null,"register":false,"type":"api-key","vaultKey":null}}` | Data Plane Authentication using the KA-EDC-AUTH-JWT extension, any entry has a type (api-key, jwt or composite) and a (set of) path contexts (see endpoints) followed by type-specific entries |
+| dataplanes.dataplane.auth.default | object | `{"apiCode":"69609650","checkExpiry":true,"context":"default","publicKey":null,"register":false,"type":"api-key","vaultKey":null}` | the default authentication service |
+| dataplanes.dataplane.auth.default.apiCode | string | `"69609650"` | specific api-code associated to the default api-key 'Hello', Change this when type=api-key or use the vault-key property instead. Althugh this represents a number, remember to use quotes not to confuse rendering into the chart. |
+| dataplanes.dataplane.auth.default.checkExpiry | bool | `true` | controls whether the expiry date of jwt tokens is checked when type=jwt |
 | dataplanes.dataplane.auth.default.context | string | `"default"` | the context(s) of the default authentication service separated by commas |
-| dataplanes.dataplane.auth.default.public-key | string | `nil` | public key for checking the validity of jwt tokens, set this when type=jwt |
+| dataplanes.dataplane.auth.default.publicKey | string | `nil` | public key for checking the validity of jwt tokens, set this when type=jwt |
 | dataplanes.dataplane.auth.default.register | bool | `false` | controls whether this service should be registered as the default EDC authentication service globally |
 | dataplanes.dataplane.auth.default.type | string | `"api-key"` | the type of the default authentication service (api-key, jwt or composite) |
-| dataplanes.dataplane.auth.default.vault-key | string | `nil` | vault key for obtaining the API key, Set this when type=api-key or use the api-code property instead |
+| dataplanes.dataplane.auth.default.vaultKey | string | `nil` | vault key for obtaining the API key, Set this when type=api-key or use the api-code property instead |
 | dataplanes.dataplane.autoscaling.enabled | bool | `false` | Enables [horizontal pod autoscaling](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) |
 | dataplanes.dataplane.autoscaling.maxReplicas | int | `100` | Maximum replicas if resource consumption exceeds resource threshholds |
 | dataplanes.dataplane.autoscaling.minReplicas | int | `1` | Minimal replicas if resource consumption falls below resource threshholds |

--- a/charts/agent-connector-azure-vault/README.md
+++ b/charts/agent-connector-azure-vault/README.md
@@ -20,14 +20,14 @@
 
 # agent-connector-azure-vault
 
-![Version: 1.9.5-SNAPSHOT](https://img.shields.io/badge/Version-1.9.5--SNAPSHOT-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.9.5-SNAPSHOT](https://img.shields.io/badge/AppVersion-1.9.5--SNAPSHOT-informational?style=flat-square)
+![Version: 1.9.7-SNAPSHOT](https://img.shields.io/badge/Version-1.9.7--SNAPSHOT-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.9.5-SNAPSHOT](https://img.shields.io/badge/AppVersion-1.9.5--SNAPSHOT-informational?style=flat-square)
 
 A Helm chart for an Agent-Enabled Tractus-X Eclipse Data Space Connector. The connector deployment consists of two runtime consists of a
 Control Plane and a Data Plane. Note that _no_ external dependencies such as a PostgreSQL database and Azure KeyVault are included.
 
 This chart is intended for use with an _existing_ PostgreSQL database and an _existing_ Azure KeyVault.
 
-**Homepage:** <https://github.com/eclipse-tractusx/knowledge-agents-edc/tree/main/charts/agent-connector>
+**Homepage:** <https://github.com/eclipse-tractusx/knowledge-agents-edc/>
 
 ## Setting up SSI
 
@@ -71,13 +71,19 @@ Combined, run this shell command to start the in-memory Tractus-X EDC runtime:
 
 ```shell
 helm repo add eclipse-tractusx https://eclipse-tractusx.github.io/charts/dev
-helm install my-release eclipse-tractusx/agent-connector-azure-vault --version 1.9.5-SNAPSHOT\
+helm install my-release eclipse-tractusx/agent-connector-azure-vault --version 1.9.7-SNAPSHOT\
      -f <path-to>/tractusx-connector-azure-vault-test.yaml \
      --set vault.azure.name=$AZURE_VAULT_NAME \
      --set vault.azure.client=$AZURE_CLIENT_ID \
      --set vault.azure.secret=$AZURE_CLIENT_SECRET \
      --set vault.azure.tenant=$AZURE_TENANT_ID
 ```
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| Tractus-X Knowledge Agents Team |  |  |
 
 ## Source Code
 
@@ -204,6 +210,15 @@ helm install my-release eclipse-tractusx/agent-connector-azure-vault --version 1
 | dataplanes.dataplane.agent.services.deny | string | `"http://.*"` | A regular expression which outgoing service URLs must not match (unless overwritten by a specific asset property) |
 | dataplanes.dataplane.agent.skillcontract | string | `"Contract?partner=Skill"` | Names the visible contract under which new skills are published (if not otherwise specified) |
 | dataplanes.dataplane.agent.synchronization | int | `-1` | The synchronization interval in ms to update the federated data catalogue |
+| dataplanes.dataplane.auth | object | `{"default":{"api-code":69609650,"check-expiry":true,"context":"default","public-key":null,"register":false,"type":"api-key","vault-key":null}}` | Data Plane Authentication using the KA-EDC-AUTH-JWT extension, any entry has a type (api-key, jwt or composite) and a (set of) path contexts (see endpoints) followed by type-specific entries |
+| dataplanes.dataplane.auth.default | object | `{"api-code":69609650,"check-expiry":true,"context":"default","public-key":null,"register":false,"type":"api-key","vault-key":null}` | the default authentication service |
+| dataplanes.dataplane.auth.default.api-code | int | `69609650` | specific api-code associated to the default api-key 'Hello', Change this when type=api-key or use the vault-key property instead |
+| dataplanes.dataplane.auth.default.check-expiry | bool | `true` | controls whether the expiry date of jwt tokens is checked when type=jwt |
+| dataplanes.dataplane.auth.default.context | string | `"default"` | the context(s) of the default authentication service separated by commas |
+| dataplanes.dataplane.auth.default.public-key | string | `nil` | public key for checking the validity of jwt tokens, set this when type=jwt |
+| dataplanes.dataplane.auth.default.register | bool | `false` | controls whether this service should be registered as the default EDC authentication service globally |
+| dataplanes.dataplane.auth.default.type | string | `"api-key"` | the type of the default authentication service (api-key, jwt or composite) |
+| dataplanes.dataplane.auth.default.vault-key | string | `nil` | vault key for obtaining the API key, Set this when type=api-key or use the api-code property instead |
 | dataplanes.dataplane.autoscaling.enabled | bool | `false` | Enables [horizontal pod autoscaling](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) |
 | dataplanes.dataplane.autoscaling.maxReplicas | int | `100` | Maximum replicas if resource consumption exceeds resource threshholds |
 | dataplanes.dataplane.autoscaling.minReplicas | int | `1` | Minimal replicas if resource consumption falls below resource threshholds |
@@ -288,6 +303,7 @@ helm install my-release eclipse-tractusx/agent-connector-azure-vault --version 1
 | dataplanes.dataplane.volumes | list | `[]` | [volume](https://kubernetes.io/docs/concepts/storage/volumes/) directories |
 | fullnameOverride | string | `""` |  |
 | imagePullSecrets | list | `[]` | Existing image pull secret to use to [obtain the container image from private registries](https://kubernetes.io/docs/concepts/containers/images/#using-a-private-registry) |
+| imageRegistry | string | `"docker.io/"` | Image registry to use |
 | install.postgresql | bool | `true` |  |
 | nameOverride | string | `""` |  |
 | networkPolicy.controlplane | object | `{"from":[{"namespaceSelector":{}}]}` | Configuration of the controlplane component |

--- a/charts/agent-connector-azure-vault/README.md.gotmpl
+++ b/charts/agent-connector-azure-vault/README.md.gotmpl
@@ -28,6 +28,22 @@
 
 {{ template "chart.homepageLine" . }}
 
+## Setting up your BPNL and the Control Plane's Management API Key
+
+The secure API-Key that is shared between control and agent plane is configured in the following property:
+- 'controlplane.endpoints.management.authKey': Cleartext API Key as used to secure the control planes management api (and is used by the agent plane to synchronize assets and negotiate calls).
+
+You should set your BPNL in the folloing property:
+- 'participant.id': 'BPNL' followed by 12 alphanumerical characters as handed out to you during onboarding.
+
+## Setting up Azure Vault
+
+You should set your BPNL in the folloing property:
+- 'vault.azure.name': Name of the vault
+- 'vault.azure.client': Id of the registered application that this EDC represents
+- 'vault.azure.tenant': Id of the subscription that the vault runs into
+- 'vault.azure.secret' or 'vault.azure.certificate': the secret/credential to use when interacting with Azure Vault
+
 ## Setting up SSI
 
 ### Preconditions
@@ -57,7 +73,22 @@ Be sure to provide the following configuration entries to your Tractus-X EDC Hel
 - `controlplane.ssi.oauth.client.id`: client ID for KeyCloak
 - `controlplane.ssi.oauth.client.secretAlias`: the alias under which the client secret is stored in the vault. Defaults to `client-secret`.
 
-Be sure to adapt the agent configuration 
+## Setting up the Agent Planes
+
+Make sure to adapt the Agent Plane's application-facing endpoint security:
+- 'dataplanes.agentplane.auth.default.type': The type of authentication service to use (defaults to api-key, you could also use jwt)
+- 'dataplanes.agentplane.auth.default.apiCode': If type is api-key, this is the hash of the accepted api key
+- 'dataplanes.agentplane.auth.default.vaultKey': If type is api-key, this is the key where the api key can be retrieved from the configured vault
+- 'dataplanes.agentplane.auth.default.publicKey': If type is jwt, this is a url where the public key to verify token with can be found
+- 'dataplanes.agentplane.auth.default.checkExpiry': If type is jwt, determines whether token expiry is checked (default: true)
+
+Be sure to review the Agent Plane's service delegation filter which regulates with which external Agent's (SERVICE) this instance may interact. These properties form typical allow/deny conditions. Because of the nature of SPARQL, interacting with such a service may not only mean to import data from there, but you must take into account bound variables in the SERVICE contexts are also exported to there. So you should be rather prohibitive here.  
+- 'dataplanes.agentplane.agent.services.allow': A regular expression of allowed Agent/Sparql SERVICE contexts in the default graph (federated data catalogue). The default graph only contains meta-data and can only be invoked by any in-house application, so usually you can be a bit more relaxed on this level. For example, you might be tempted to allow to mix your application logic and data with some universal service, such as Wikidata.
+- 'dataplanes.agentplane.agent.services.deny': A regular expression of denied outgoing Agent/Sparql SERVICE contexts in the default graph (federated data catalogue). Typically you would restrict any unsecured http call by this properties.
+- 'dataplanes.agentplane.agent.services.assets.allow': A regular expression of allowed Agent/Sparql SERVICE contexts when inside a data graph/asset (unless there are more specific settings in the asset itself). Since this affects how you can spice up your business data, you would only allow connections to trusted business partners connectors.
+- 'dataplanes.agentplane.agent.services.assets.deny': A regular expression of denied Agent/Sparql SERVICE contexts. Use this to filter out unsecure protocols such as edc and http as well as to implement blacklists.
+
+Be sure to adapt the agent configuration
 - 'dataplanes.agentplane.configs.dataspace.ttl': additional TTL text resource which lists the partner BPNs and their associated connectors.
 - 'dataplanes.agentplane.agent.maxbatchsize': Should be restricted to a smaller number of tuples (10-100) if you intend to communicate over larger datasets.
 - 'dataplanes.agentplane.agent.synchronization': Should be set to a positive number of seconds to activate the automatic synchronization of federated data catalogues.

--- a/charts/agent-connector-azure-vault/templates/deployment-dataplane.yaml
+++ b/charts/agent-connector-azure-vault/templates/deployment-dataplane.yaml
@@ -129,7 +129,40 @@ spec:
             - name: "EDC_DATAPLANE_TOKEN_VALIDATION_ENDPOINT"
               value: {{ include "txdc.controlplane.url.validation" $root}}
 
+            ###################
+            # AUTH (JWT)      #
+            ###################
+          {{- if $dataplane.auth }}
+          {{- range $auth, $authDef := $dataplane.auth }} 
+            - name: {{ printf "TRACTUSX_AUTH_%s_TYPE" (upper $auth) | quote }}
+              value: {{ $authDef.type | required "Authentication Service needs a type" | quote }}
+            - name: {{ printf "TRACTUSX_AUTH_%s_PATHS" (upper $auth) | quote }}
+              value: {{ $authDef.context | required "Authentication Service needs a context" | quote }}
+          {{- if $authDef.register }}   
+            - name: {{ printf "TRACTUSX_AUTH_%s_REGISTER" (upper $auth) | quote }}
+              value: {{ $authDef.register | quote }}
+          {{- end }}
+          {{- if $authDef.apiCode }}   
+            - name: {{ printf "TRACTUSX_AUTH_%s_API_CODE" (upper $auth) | quote }}
+              value: {{ $authDef.apiCode | quote }}
+          {{- end }}
+          {{- if $authDef.vaultKey }}   
+            - name: {{ printf "TRACTUSX_AUTH_%s_VAULT_KEY" (upper $auth) | quote }}
+              value: {{ $authDef.vaultKey | quote }}
+          {{- end }}
+          {{- if $authDef.publicKey }}   
+            - name: {{ printf "TRACTUSX_AUTH_%s_PUBLICKEY" (upper $auth) | quote }}
+              value: {{ $authDef.publicKey | quote }}
+          {{- end }}
+          {{- if $authDef.checkExpiry }}   
+            - name: {{ printf "TRACTUSX_AUTH_%s_CHECKEXPIRY" (upper $auth) | quote }}
+              value: {{ $authDef.checkExpiry | quote }}
+          {{- end }}
+          {{- end }}
+          {{- end }}
+
           {{- if $dataplane.endpoints.callback }}
+
             ###################
             # AGENT CALLBACK  #
             ###################
@@ -150,6 +183,7 @@ spec:
           {{- end }}
 
           {{- if $dataplane.agent.default }}
+
             ###############
             # AGENT INIT  #
             ###############
@@ -160,6 +194,7 @@ spec:
           {{- end }}
 
           {{- if $dataplane.agent.services }}
+
             ###################
             # AGENT SERVICES #
             ###################
@@ -185,6 +220,7 @@ spec:
 
           
           {{- if $dataplane.agent.connectors }}
+
             ###################
             # AGENT SYNC      #
             ###################

--- a/charts/agent-connector-azure-vault/values.yaml
+++ b/charts/agent-connector-azure-vault/values.yaml
@@ -367,6 +367,24 @@ dataplanes:
       metrics:
         port: 9090
         path: /metrics
+    # -- Data Plane Authentication using the KA-EDC-AUTH-JWT extension, any entry has a type (api-key, jwt or composite) and a (set of) path contexts (see endpoints) followed by type-specific entries
+    auth:
+      # -- the default authentication service
+      default:
+        # -- the type of the default authentication service (api-key, jwt or composite)
+        type: api-key
+        # -- the context(s) of the default authentication service separated by commas
+        context: default
+        # -- controls whether this service should be registered as the default EDC authentication service globally
+        register: false
+        # -- specific api-code associated to the default api-key 'Hello', Change this when type=api-key or use the vault-key property instead. Althugh this represents a number, remember to use quotes not to confuse rendering into the chart.
+        apiCode: "69609650"
+        # -- vault key for obtaining the API key, Set this when type=api-key or use the api-code property instead
+        vaultKey:
+        # -- public key for checking the validity of jwt tokens, set this when type=jwt
+        publicKey:
+        # -- controls whether the expiry date of jwt tokens is checked when type=jwt
+        checkExpiry: true
     aws:
       endpointOverride: ""
       accessKeyId: ""

--- a/charts/agent-connector-memory/Chart.yaml
+++ b/charts/agent-connector-memory/Chart.yaml
@@ -25,7 +25,7 @@
 apiVersion: v2
 name: agent-connector-memory
 description: |
-  A Helm chart for an Agent-Enabled Tractus-X Eclipse Data Space Connector using In-Memory Persistence. This is a variant of [the Tractus-X In-Memory Connector Helm Chart](https://github.com/eclipse-tractusx/tractusx-edc/tree/main/charts/tractusx-connector-memory) which allows 
+  A Helm chart for an Agent-Enabled Tractus-X Eclipse Data Space Connector using In-Memory Persistence. This is a variant of [the Tractus-X In-Memory Connector Helm Chart](https://github.com/eclipse-tractusx/tractusx-edc/tree/main/charts/tractusx-connector-memory) which allows
   to deal with several data (and agent) planes. The connector deployment consists of at least two runtime consists of a
   Control Plane and one or several Data Planes. Note that _no_ external dependencies such as HashiCorp Vault are included.
 

--- a/charts/agent-connector-memory/Chart.yaml
+++ b/charts/agent-connector-memory/Chart.yaml
@@ -25,8 +25,9 @@
 apiVersion: v2
 name: agent-connector-memory
 description: |
-  A Helm chart for an Agent-Enabled Tractus-X Eclipse Data Space Connector. The connector deployment consists of two runtime consists of a
-  Control Plane and a Data Plane. Note that _no_ external dependencies such as HashiCorp Vault are included.
+  A Helm chart for an Agent-Enabled Tractus-X Eclipse Data Space Connector using In-Memory Persistence. This is a variant of [the Tractus-X In-Memory Connector Helm Chart](https://github.com/eclipse-tractusx/tractusx-edc/tree/main/charts/tractusx-connector-memory) which allows 
+  to deal with several data (and agent) planes. The connector deployment consists of at least two runtime consists of a
+  Control Plane and one or several Data Planes. Note that _no_ external dependencies such as HashiCorp Vault are included.
 
   This chart is intended for use with an _existing_ HashiCorp Vault.
 # A chart can be either an 'application' or a 'library' chart.
@@ -41,7 +42,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.9.6-SNAPSHOT
+version: 1.9.7-SNAPSHOT
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/agent-connector-memory/README.md
+++ b/charts/agent-connector-memory/README.md
@@ -20,14 +20,14 @@
 
 # agent-connector-memory
 
-![Version: 1.9.5-SNAPSHOT](https://img.shields.io/badge/Version-1.9.5--SNAPSHOT-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.9.5-SNAPSHOT](https://img.shields.io/badge/AppVersion-1.9.5--SNAPSHOT-informational?style=flat-square)
+![Version: 1.9.7-SNAPSHOT](https://img.shields.io/badge/Version-1.9.7--SNAPSHOT-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.9.5-SNAPSHOT](https://img.shields.io/badge/AppVersion-1.9.5--SNAPSHOT-informational?style=flat-square)
 
 A Helm chart for an Agent-Enabled Tractus-X Eclipse Data Space Connector. The connector deployment consists of two runtime consists of a
 Control Plane and a Data Plane. Note that _no_ external dependencies such as HashiCorp Vault are included.
 
 This chart is intended for use with an _existing_ HashiCorp Vault.
 
-**Homepage:** <https://github.com/eclipse-tractusx/knowledge-agents-edc/tree/main/charts/agent-connector>
+**Homepage:** <https://github.com/eclipse-tractusx/knowledge-agents-edc/>
 
 ## Setting up SSI
 
@@ -68,8 +68,14 @@ Combined, run this shell command to start the in-memory Tractus-X EDC runtime:
 
 ```shell
 helm repo add eclipse-tractusx https://eclipse-tractusx.github.io/charts/dev
-helm install my-release eclipse-tractusx/agent-connector --version 1.9.5-SNAPSHOT
+helm install my-release eclipse-tractusx/agent-connector --version 1.9.7-SNAPSHOT
 ```
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| Tractus-X Knowledge Agents Team |  |  |
 
 ## Source Code
 
@@ -196,6 +202,15 @@ helm install my-release eclipse-tractusx/agent-connector --version 1.9.5-SNAPSHO
 | dataplanes.dataplane.agent.services.deny | string | `"http://.*"` | A regular expression which outgoing service URLs must not match (unless overwritten by a specific asset property) |
 | dataplanes.dataplane.agent.skillcontract | string | `"Contract?partner=Skill"` | Names the visible contract under which new skills are published (if not otherwise specified) |
 | dataplanes.dataplane.agent.synchronization | int | `-1` | The synchronization interval in ms to update the federated data catalogue |
+| dataplanes.dataplane.auth | object | `{"default":{"api-code":69609650,"check-expiry":true,"context":"default","public-key":null,"register":false,"type":"api-key","vault-key":null}}` | Data Plane Authentication using the KA-EDC-AUTH-JWT extension, any entry has a type (api-key, jwt or composite) and a (set of) path contexts (see endpoints) followed by type-specific entries |
+| dataplanes.dataplane.auth.default | object | `{"api-code":69609650,"check-expiry":true,"context":"default","public-key":null,"register":false,"type":"api-key","vault-key":null}` | the default authentication service |
+| dataplanes.dataplane.auth.default.api-code | int | `69609650` | specific api-code associated to the default api-key 'Hello', Change this when type=api-key or use the vault-key property instead |
+| dataplanes.dataplane.auth.default.check-expiry | bool | `true` | controls whether the expiry date of jwt tokens is checked when type=jwt |
+| dataplanes.dataplane.auth.default.context | string | `"default"` | the context(s) of the default authentication service separated by commas |
+| dataplanes.dataplane.auth.default.public-key | string | `nil` | public key for checking the validity of jwt tokens, set this when type=jwt |
+| dataplanes.dataplane.auth.default.register | bool | `false` | controls whether this service should be registered as the default EDC authentication service globally |
+| dataplanes.dataplane.auth.default.type | string | `"api-key"` | the type of the default authentication service (api-key, jwt or composite) |
+| dataplanes.dataplane.auth.default.vault-key | string | `nil` | vault key for obtaining the API key, Set this when type=api-key or use the api-code property instead |
 | dataplanes.dataplane.autoscaling.enabled | bool | `false` | Enables [horizontal pod autoscaling](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) |
 | dataplanes.dataplane.autoscaling.maxReplicas | int | `100` | Maximum replicas if resource consumption exceeds resource threshholds |
 | dataplanes.dataplane.autoscaling.minReplicas | int | `1` | Minimal replicas if resource consumption falls below resource threshholds |
@@ -280,6 +295,7 @@ helm install my-release eclipse-tractusx/agent-connector --version 1.9.5-SNAPSHO
 | dataplanes.dataplane.volumes | list | `[]` | [volume](https://kubernetes.io/docs/concepts/storage/volumes/) directories |
 | fullnameOverride | string | `""` |  |
 | imagePullSecrets | list | `[]` | Existing image pull secret to use to [obtain the container image from private registries](https://kubernetes.io/docs/concepts/containers/images/#using-a-private-registry) |
+| imageRegistry | string | `"docker.io/"` | Image registry to use |
 | install.vault | bool | `false` |  |
 | nameOverride | string | `""` |  |
 | networkPolicy.controlplane | object | `{"from":[{"namespaceSelector":{}}]}` | Configuration of the controlplane component |

--- a/charts/agent-connector-memory/README.md
+++ b/charts/agent-connector-memory/README.md
@@ -22,12 +22,27 @@
 
 ![Version: 1.9.7-SNAPSHOT](https://img.shields.io/badge/Version-1.9.7--SNAPSHOT-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.9.5-SNAPSHOT](https://img.shields.io/badge/AppVersion-1.9.5--SNAPSHOT-informational?style=flat-square)
 
-A Helm chart for an Agent-Enabled Tractus-X Eclipse Data Space Connector. The connector deployment consists of two runtime consists of a
-Control Plane and a Data Plane. Note that _no_ external dependencies such as HashiCorp Vault are included.
+A Helm chart for an Agent-Enabled Tractus-X Eclipse Data Space Connector using In-Memory Persistence. This is a variant of [the Tractus-X In-Memory Connector Helm Chart](https://github.com/eclipse-tractusx/tractusx-edc/tree/main/charts/tractusx-connector-memory) which allows
+to deal with several data (and agent) planes. The connector deployment consists of at least two runtime consists of a
+Control Plane and one or several Data Planes. Note that _no_ external dependencies such as HashiCorp Vault are included.
 
 This chart is intended for use with an _existing_ HashiCorp Vault.
 
 **Homepage:** <https://github.com/eclipse-tractusx/knowledge-agents-edc/>
+
+## Setting up your BPNL and the Control Plane's Management API Key
+
+The secure API-Key that is shared between control and agent plane is configured in the following property:
+- 'controlplane.endpoints.management.authKey': Cleartext API Key as used to secure the control planes management api (and is used by the agent plane to synchronize assets and negotiate calls).
+
+You should set your BPNL in the folloing property:
+- 'participant.id': 'BPNL' followed by 12 alphanumerical characters as handed out to you during onboarding.
+
+## Setting up Hashicorp Vault
+
+You should set your BPNL in the folloing property:
+- 'vault.hashicorp.url': URL of the vault API
+- 'vault.hashicorp.token': A valid, generated access token.
 
 ## Setting up SSI
 
@@ -53,6 +68,21 @@ Be sure to provide the following configuration entries to your Tractus-X EDC Hel
 - `controlplane.ssi.oauth.tokenurl`: the URL (of KeyCloak), where access tokens can be obtained
 - `controlplane.ssi.oauth.client.id`: client ID for KeyCloak
 - `controlplane.ssi.oauth.client.secretAlias`: the alias under which the client secret is stored in the vault. Defaults to `client-secret`.
+
+## Setting up the Agent Planes
+
+Make sure to adapt the Agent Plane's application-facing endpoint security:
+- 'dataplanes.agentplane.auth.default.type': The type of authentication service to use (defaults to api-key, you could also use jwt)
+- 'dataplanes.agentplane.auth.default.apiCode': If type is api-key, this is the hash of the accepted api key
+- 'dataplanes.agentplane.auth.default.vaultKey': If type is api-key, this is the key where the api key can be retrieved from the configured vault
+- 'dataplanes.agentplane.auth.default.publicKey': If type is jwt, this is a url where the public key to verify token with can be found
+- 'dataplanes.agentplane.auth.default.checkExpiry': If type is jwt, determines whether token expiry is checked (default: true)
+
+Be sure to review the Agent Plane's service delegation filter which regulates with which external Agent's (SERVICE) this instance may interact. These properties form typical allow/deny conditions. Because of the nature of SPARQL, interacting with such a service may not only mean to import data from there, but you must take into account bound variables in the SERVICE contexts are also exported to there. So you should be rather prohibitive here. 
+- 'dataplanes.agentplane.agent.services.allow': A regular expression of allowed Agent/Sparql SERVICE contexts in the default graph (federated data catalogue). The default graph only contains meta-data and can only be invoked by any in-house application, so usually you can be a bit more relaxed on this level. For example, you might be tempted to allow to mix your application logic and data with some universal service, such as Wikidata.
+- 'dataplanes.agentplane.agent.services.deny': A regular expression of denied outgoing Agent/Sparql SERVICE contexts in the default graph (federated data catalogue). Typically you would restrict any unsecured http call by this properties.
+- 'dataplanes.agentplane.agent.services.assets.allow': A regular expression of allowed Agent/Sparql SERVICE contexts when inside a data graph/asset (unless there are more specific settings in the asset itself). Since this affects how you can spice up your business data, you would only allow connections to trusted business partners connectors.
+- 'dataplanes.agentplane.agent.services.assets.deny': A regular expression of denied Agent/Sparql SERVICE contexts. Use this to filter out unsecure protocols such as edc and http as well as to implement blacklists.
 
 Be sure to adapt the agent configuration
 - 'dataplanes.agentplane.configs.dataspace.ttl': additional TTL text resource which lists the partner BPNs and their associated connectors.
@@ -202,15 +232,15 @@ helm install my-release eclipse-tractusx/agent-connector --version 1.9.7-SNAPSHO
 | dataplanes.dataplane.agent.services.deny | string | `"http://.*"` | A regular expression which outgoing service URLs must not match (unless overwritten by a specific asset property) |
 | dataplanes.dataplane.agent.skillcontract | string | `"Contract?partner=Skill"` | Names the visible contract under which new skills are published (if not otherwise specified) |
 | dataplanes.dataplane.agent.synchronization | int | `-1` | The synchronization interval in ms to update the federated data catalogue |
-| dataplanes.dataplane.auth | object | `{"default":{"api-code":69609650,"check-expiry":true,"context":"default","public-key":null,"register":false,"type":"api-key","vault-key":null}}` | Data Plane Authentication using the KA-EDC-AUTH-JWT extension, any entry has a type (api-key, jwt or composite) and a (set of) path contexts (see endpoints) followed by type-specific entries |
-| dataplanes.dataplane.auth.default | object | `{"api-code":69609650,"check-expiry":true,"context":"default","public-key":null,"register":false,"type":"api-key","vault-key":null}` | the default authentication service |
-| dataplanes.dataplane.auth.default.api-code | int | `69609650` | specific api-code associated to the default api-key 'Hello', Change this when type=api-key or use the vault-key property instead |
-| dataplanes.dataplane.auth.default.check-expiry | bool | `true` | controls whether the expiry date of jwt tokens is checked when type=jwt |
+| dataplanes.dataplane.auth | object | `{"default":{"apiCode":"69609650","checkExpiry":true,"context":"default","publicKey":null,"register":false,"type":"api-key","vaultKey":null}}` | Data Plane Authentication using the KA-EDC-AUTH-JWT extension, any entry has a type (api-key, jwt or composite) and a (set of) path contexts (see endpoints) followed by type-specific entries |
+| dataplanes.dataplane.auth.default | object | `{"apiCode":"69609650","checkExpiry":true,"context":"default","publicKey":null,"register":false,"type":"api-key","vaultKey":null}` | the default authentication service |
+| dataplanes.dataplane.auth.default.apiCode | string | `"69609650"` | specific api-code associated to the default api-key 'Hello', Change this when type=api-key or use the vault-key property instead. Althugh this represents a number, remember to use quotes not to confuse rendering into the chart. |
+| dataplanes.dataplane.auth.default.checkExpiry | bool | `true` | controls whether the expiry date of jwt tokens is checked when type=jwt |
 | dataplanes.dataplane.auth.default.context | string | `"default"` | the context(s) of the default authentication service separated by commas |
-| dataplanes.dataplane.auth.default.public-key | string | `nil` | public key for checking the validity of jwt tokens, set this when type=jwt |
+| dataplanes.dataplane.auth.default.publicKey | string | `nil` | public key for checking the validity of jwt tokens, set this when type=jwt |
 | dataplanes.dataplane.auth.default.register | bool | `false` | controls whether this service should be registered as the default EDC authentication service globally |
 | dataplanes.dataplane.auth.default.type | string | `"api-key"` | the type of the default authentication service (api-key, jwt or composite) |
-| dataplanes.dataplane.auth.default.vault-key | string | `nil` | vault key for obtaining the API key, Set this when type=api-key or use the api-code property instead |
+| dataplanes.dataplane.auth.default.vaultKey | string | `nil` | vault key for obtaining the API key, Set this when type=api-key or use the api-code property instead |
 | dataplanes.dataplane.autoscaling.enabled | bool | `false` | Enables [horizontal pod autoscaling](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) |
 | dataplanes.dataplane.autoscaling.maxReplicas | int | `100` | Maximum replicas if resource consumption exceeds resource threshholds |
 | dataplanes.dataplane.autoscaling.minReplicas | int | `1` | Minimal replicas if resource consumption falls below resource threshholds |

--- a/charts/agent-connector-memory/README.md.gotmpl
+++ b/charts/agent-connector-memory/README.md.gotmpl
@@ -28,6 +28,20 @@
 
 {{ template "chart.homepageLine" . }}
 
+## Setting up your BPNL and the Control Plane's Management API Key
+
+The secure API-Key that is shared between control and agent plane is configured in the following property:
+- 'controlplane.endpoints.management.authKey': Cleartext API Key as used to secure the control planes management api (and is used by the agent plane to synchronize assets and negotiate calls).
+
+You should set your BPNL in the folloing property:
+- 'participant.id': 'BPNL' followed by 12 alphanumerical characters as handed out to you during onboarding.
+
+## Setting up Hashicorp Vault
+
+You should set your BPNL in the folloing property:
+- 'vault.hashicorp.url': URL of the vault API
+- 'vault.hashicorp.token': A valid, generated access token.
+
 ## Setting up SSI
 
 ### Preconditions
@@ -54,7 +68,22 @@ Be sure to provide the following configuration entries to your Tractus-X EDC Hel
 - `controlplane.ssi.oauth.client.id`: client ID for KeyCloak
 - `controlplane.ssi.oauth.client.secretAlias`: the alias under which the client secret is stored in the vault. Defaults to `client-secret`.
 
-Be sure to adapt the agent configuration 
+## Setting up the Agent Planes
+
+Make sure to adapt the Agent Plane's application-facing endpoint security:
+- 'dataplanes.agentplane.auth.default.type': The type of authentication service to use (defaults to api-key, you could also use jwt)
+- 'dataplanes.agentplane.auth.default.apiCode': If type is api-key, this is the hash of the accepted api key
+- 'dataplanes.agentplane.auth.default.vaultKey': If type is api-key, this is the key where the api key can be retrieved from the configured vault
+- 'dataplanes.agentplane.auth.default.publicKey': If type is jwt, this is a url where the public key to verify token with can be found
+- 'dataplanes.agentplane.auth.default.checkExpiry': If type is jwt, determines whether token expiry is checked (default: true)
+
+Be sure to review the Agent Plane's service delegation filter which regulates with which external Agent's (SERVICE) this instance may interact. These properties form typical allow/deny conditions. Because of the nature of SPARQL, interacting with such a service may not only mean to import data from there, but you must take into account bound variables in the SERVICE contexts are also exported to there. So you should be rather prohibitive here.  
+- 'dataplanes.agentplane.agent.services.allow': A regular expression of allowed Agent/Sparql SERVICE contexts in the default graph (federated data catalogue). The default graph only contains meta-data and can only be invoked by any in-house application, so usually you can be a bit more relaxed on this level. For example, you might be tempted to allow to mix your application logic and data with some universal service, such as Wikidata.
+- 'dataplanes.agentplane.agent.services.deny': A regular expression of denied outgoing Agent/Sparql SERVICE contexts in the default graph (federated data catalogue). Typically you would restrict any unsecured http call by this properties.
+- 'dataplanes.agentplane.agent.services.assets.allow': A regular expression of allowed Agent/Sparql SERVICE contexts when inside a data graph/asset (unless there are more specific settings in the asset itself). Since this affects how you can spice up your business data, you would only allow connections to trusted business partners connectors.
+- 'dataplanes.agentplane.agent.services.assets.deny': A regular expression of denied Agent/Sparql SERVICE contexts. Use this to filter out unsecure protocols such as edc and http as well as to implement blacklists.
+
+Be sure to adapt the agent configuration
 - 'dataplanes.agentplane.configs.dataspace.ttl': additional TTL text resource which lists the partner BPNs and their associated connectors.
 - 'dataplanes.agentplane.agent.maxbatchsize': Should be restricted to a smaller number of tuples (10-100) if you intend to communicate over larger datasets.
 - 'dataplanes.agentplane.agent.synchronization': Should be set to a positive number of seconds to activate the automatic synchronization of federated data catalogues.

--- a/charts/agent-connector-memory/templates/deployment-dataplane.yaml
+++ b/charts/agent-connector-memory/templates/deployment-dataplane.yaml
@@ -129,7 +129,40 @@ spec:
             - name: "EDC_DATAPLANE_TOKEN_VALIDATION_ENDPOINT"
               value: {{ include "txdc.controlplane.url.validation" $root}}
 
+            ###################
+            # AUTH (JWT)      #
+            ###################
+          {{- if $dataplane.auth }}
+          {{- range $auth, $authDef := $dataplane.auth }} 
+            - name: {{ printf "TRACTUSX_AUTH_%s_TYPE" (upper $auth) | quote }}
+              value: {{ $authDef.type | required "Authentication Service needs a type" | quote }}
+            - name: {{ printf "TRACTUSX_AUTH_%s_PATHS" (upper $auth) | quote }}
+              value: {{ $authDef.context | required "Authentication Service needs a context" | quote }}
+          {{- if $authDef.register }}   
+            - name: {{ printf "TRACTUSX_AUTH_%s_REGISTER" (upper $auth) | quote }}
+              value: {{ $authDef.register | quote }}
+          {{- end }}
+          {{- if $authDef.apiCode }}   
+            - name: {{ printf "TRACTUSX_AUTH_%s_API_CODE" (upper $auth) | quote }}
+              value: {{ $authDef.apiCode | quote }}
+          {{- end }}
+          {{- if $authDef.vaultKey }}   
+            - name: {{ printf "TRACTUSX_AUTH_%s_VAULT_KEY" (upper $auth) | quote }}
+              value: {{ $authDef.vaultKey | quote }}
+          {{- end }}
+          {{- if $authDef.publicKey }}   
+            - name: {{ printf "TRACTUSX_AUTH_%s_PUBLICKEY" (upper $auth) | quote }}
+              value: {{ $authDef.publicKey | quote }}
+          {{- end }}
+          {{- if $authDef.checkExpiry }}   
+            - name: {{ printf "TRACTUSX_AUTH_%s_CHECKEXPIRY" (upper $auth) | quote }}
+              value: {{ $authDef.checkExpiry | quote }}
+          {{- end }}
+          {{- end }}
+          {{- end }}
+
           {{- if $dataplane.endpoints.callback }}
+
             ###################
             # AGENT CALLBACK  #
             ###################
@@ -150,6 +183,7 @@ spec:
           {{- end }}
 
           {{- if $dataplane.agent.default }}
+
             ###############
             # AGENT INIT  #
             ###############
@@ -160,6 +194,7 @@ spec:
           {{- end }}
 
           {{- if $dataplane.agent.services }}
+
             ###################
             # AGENT SERVICES #
             ###################
@@ -184,6 +219,7 @@ spec:
           {{- end }}
           
           {{- if $dataplane.agent.connectors }}
+
             ###################
             # AGENT SYNC      #
             ###################

--- a/charts/agent-connector-memory/values.yaml
+++ b/charts/agent-connector-memory/values.yaml
@@ -364,6 +364,24 @@ dataplanes:
       metrics:
         port: 9090
         path: /metrics
+    # -- Data Plane Authentication using the KA-EDC-AUTH-JWT extension, any entry has a type (api-key, jwt or composite) and a (set of) path contexts (see endpoints) followed by type-specific entries
+    auth:
+      # -- the default authentication service
+      default:
+        # -- the type of the default authentication service (api-key, jwt or composite)
+        type: api-key
+        # -- the context(s) of the default authentication service separated by commas
+        context: default
+        # -- controls whether this service should be registered as the default EDC authentication service globally
+        register: false
+        # -- specific api-code associated to the default api-key 'Hello', Change this when type=api-key or use the vault-key property instead. Althugh this represents a number, remember to use quotes not to confuse rendering into the chart.
+        apiCode: "69609650"
+        # -- vault key for obtaining the API key, Set this when type=api-key or use the api-code property instead
+        vaultKey:
+        # -- public key for checking the validity of jwt tokens, set this when type=jwt
+        publicKey:
+        # -- controls whether the expiry date of jwt tokens is checked when type=jwt
+        checkExpiry: true
     aws:
       endpointOverride: ""
       accessKeyId: ""

--- a/charts/agent-connector/Chart.yaml
+++ b/charts/agent-connector/Chart.yaml
@@ -24,8 +24,9 @@
 apiVersion: v2
 name: agent-connector
 description: |
-  A Helm chart for an Agent-Enabled Tractus-X Eclipse Data Space Connector. The connector deployment consists of two runtime consists of a
-  Control Plane and a Data Plane. Note that _no_ external dependencies such as a PostgreSQL database and HashiCorp Vault are included.
+  A Helm chart for an Agent-Enabled Tractus-X Eclipse Data Space Connector. This is a variant of [the Tractus-X Connector Helm Chart](https://github.com/eclipse-tractusx/tractusx-edc/tree/main/charts/tractusx-connector) which allows 
+  to deal with several data (and agent) planes. The connector deployment consists of at least two runtime consists of a
+  Control Plane and one or several Data Planes. Note that _no_ external dependencies such as a PostgreSQL database and HashiCorp Vault are included.
 
   This chart is intended for use with an _existing_ PostgreSQL database and an _existing_ HashiCorp Vault.
 # A chart can be either an 'application' or a 'library' chart.
@@ -40,7 +41,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.9.6-SNAPSHOT
+version: 1.9.7-SNAPSHOT
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/agent-connector/Chart.yaml
+++ b/charts/agent-connector/Chart.yaml
@@ -24,7 +24,7 @@
 apiVersion: v2
 name: agent-connector
 description: |
-  A Helm chart for an Agent-Enabled Tractus-X Eclipse Data Space Connector. This is a variant of [the Tractus-X Connector Helm Chart](https://github.com/eclipse-tractusx/tractusx-edc/tree/main/charts/tractusx-connector) which allows 
+  A Helm chart for an Agent-Enabled Tractus-X Eclipse Data Space Connector. This is a variant of [the Tractus-X Connector Helm Chart](https://github.com/eclipse-tractusx/tractusx-edc/tree/main/charts/tractusx-connector) which allows
   to deal with several data (and agent) planes. The connector deployment consists of at least two runtime consists of a
   Control Plane and one or several Data Planes. Note that _no_ external dependencies such as a PostgreSQL database and HashiCorp Vault are included.
 

--- a/charts/agent-connector/README.md
+++ b/charts/agent-connector/README.md
@@ -22,12 +22,27 @@
 
 ![Version: 1.9.7-SNAPSHOT](https://img.shields.io/badge/Version-1.9.7--SNAPSHOT-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.9.5-SNAPSHOT](https://img.shields.io/badge/AppVersion-1.9.5--SNAPSHOT-informational?style=flat-square)
 
-A Helm chart for an Agent-Enabled Tractus-X Eclipse Data Space Connector. The connector deployment consists of two runtime consists of a
-Control Plane and a Data Plane. Note that _no_ external dependencies such as a PostgreSQL database and HashiCorp Vault are included.
+A Helm chart for an Agent-Enabled Tractus-X Eclipse Data Space Connector. This is a variant of [the Tractus-X Connector Helm Chart](https://github.com/eclipse-tractusx/tractusx-edc/tree/main/charts/tractusx-connector) which allows
+to deal with several data (and agent) planes. The connector deployment consists of at least two runtime consists of a
+Control Plane and one or several Data Planes. Note that _no_ external dependencies such as a PostgreSQL database and HashiCorp Vault are included.
 
 This chart is intended for use with an _existing_ PostgreSQL database and an _existing_ HashiCorp Vault.
 
 **Homepage:** <https://github.com/eclipse-tractusx/knowledge-agents-edc/>
+
+## Setting up your BPNL and the Control Plane's Management API Key
+
+The secure API-Key that is shared between control and agent plane is configured in the following property:
+- 'controlplane.endpoints.management.authKey': Cleartext API Key as used to secure the control planes management api (and is used by the agent plane to synchronize assets and negotiate calls).
+
+You should set your BPNL in the folloing property:
+- 'participant.id': 'BPNL' followed by 12 alphanumerical characters as handed out to you during onboarding.
+
+## Setting up Hashicorp Vault
+
+You should set your BPNL in the folloing property:
+- 'vault.hashicorp.url': URL of the vault API
+- 'vault.hashicorp.token': A valid, generated access token.
 
 ## Setting up SSI
 
@@ -53,6 +68,21 @@ Be sure to provide the following configuration entries to your Tractus-X EDC Hel
 - `controlplane.ssi.oauth.tokenurl`: the URL (of KeyCloak), where access tokens can be obtained
 - `controlplane.ssi.oauth.client.id`: client ID for KeyCloak
 - `controlplane.ssi.oauth.client.secretAlias`: the alias under which the client secret is stored in the vault. Defaults to `client-secret`.
+
+## Setting up the Agent Planes
+
+Make sure to adapt the Agent Plane's application-facing endpoint security:
+- 'dataplanes.agentplane.auth.default.type': The type of authentication service to use (defaults to api-key, you could also use jwt)
+- 'dataplanes.agentplane.auth.default.apiCode': If type is api-key, this is the hash of the accepted api key
+- 'dataplanes.agentplane.auth.default.vaultKey': If type is api-key, this is the key where the api key can be retrieved from the configured vault
+- 'dataplanes.agentplane.auth.default.publicKey': If type is jwt, this is a url where the public key to verify token with can be found
+- 'dataplanes.agentplane.auth.default.checkExpiry': If type is jwt, determines whether token expiry is checked (default: true)
+
+Be sure to review the Agent Plane's service delegation filter which regulates with which external Agent's (SERVICE) this instance may interact. These properties form typical allow/deny conditions. Because of the nature of SPARQL, interacting with such a service may not only mean to import data from there, but you must take into account bound variables in the SERVICE contexts are also exported to there. So you should be rather prohibitive here. 
+- 'dataplanes.agentplane.agent.services.allow': A regular expression of allowed Agent/Sparql SERVICE contexts in the default graph (federated data catalogue). The default graph only contains meta-data and can only be invoked by any in-house application, so usually you can be a bit more relaxed on this level. For example, you might be tempted to allow to mix your application logic and data with some universal service, such as Wikidata.
+- 'dataplanes.agentplane.agent.services.deny': A regular expression of denied outgoing Agent/Sparql SERVICE contexts in the default graph (federated data catalogue). Typically you would restrict any unsecured http call by this properties.
+- 'dataplanes.agentplane.agent.services.assets.allow': A regular expression of allowed Agent/Sparql SERVICE contexts when inside a data graph/asset (unless there are more specific settings in the asset itself). Since this affects how you can spice up your business data, you would only allow connections to trusted business partners connectors.
+- 'dataplanes.agentplane.agent.services.assets.deny': A regular expression of denied Agent/Sparql SERVICE contexts. Use this to filter out unsecure protocols such as edc and http as well as to implement blacklists.
 
 Be sure to adapt the agent configuration
 - 'dataplanes.agentplane.configs.dataspace.ttl': additional TTL text resource which lists the partner BPNs and their associated connectors.
@@ -203,15 +233,15 @@ helm install my-release eclipse-tractusx/agent-connector --version 1.9.7-SNAPSHO
 | dataplanes.dataplane.agent.services.deny | string | `"http://.*"` | A regular expression which outgoing service URLs must not match (unless overwritten by a specific asset property) |
 | dataplanes.dataplane.agent.skillcontract | string | `"Contract?partner=Skill"` | Names the visible contract under which new skills are published (if not otherwise specified) |
 | dataplanes.dataplane.agent.synchronization | int | `-1` | The synchronization interval in ms to update the federated data catalogue |
-| dataplanes.dataplane.auth | object | `{"default":{"api-code":69609650,"check-expiry":true,"context":"default","public-key":null,"register":false,"type":"api-key","vault-key":null}}` | Data Plane Authentication using the KA-EDC-AUTH-JWT extension, any entry has a type (api-key, jwt or composite) and a (set of) path contexts (see endpoints) followed by type-specific entries |
-| dataplanes.dataplane.auth.default | object | `{"api-code":69609650,"check-expiry":true,"context":"default","public-key":null,"register":false,"type":"api-key","vault-key":null}` | the default authentication service |
-| dataplanes.dataplane.auth.default.api-code | int | `69609650` | specific api-code associated to the default api-key 'Hello', Change this when type=api-key or use the vault-key property instead |
-| dataplanes.dataplane.auth.default.check-expiry | bool | `true` | controls whether the expiry date of jwt tokens is checked when type=jwt |
+| dataplanes.dataplane.auth | object | `{"default":{"apiCode":"69609650","checkExpiry":true,"context":"default","publicKey":null,"register":false,"type":"api-key","vaultKey":null}}` | Data Plane Authentication using the KA-EDC-AUTH-JWT extension, any entry has a type (api-key, jwt or composite) and a (set of) path contexts (see endpoints) followed by type-specific entries |
+| dataplanes.dataplane.auth.default | object | `{"apiCode":"69609650","checkExpiry":true,"context":"default","publicKey":null,"register":false,"type":"api-key","vaultKey":null}` | the default authentication service |
+| dataplanes.dataplane.auth.default.apiCode | string | `"69609650"` | specific api-code associated to the default api-key 'Hello', Change this when type=api-key or use the vault-key property instead. Althugh this represents a number, remember to use quotes not to confuse rendering into the chart. |
+| dataplanes.dataplane.auth.default.checkExpiry | bool | `true` | controls whether the expiry date of jwt tokens is checked when type=jwt |
 | dataplanes.dataplane.auth.default.context | string | `"default"` | the context(s) of the default authentication service separated by commas |
-| dataplanes.dataplane.auth.default.public-key | string | `nil` | public key for checking the validity of jwt tokens, set this when type=jwt |
+| dataplanes.dataplane.auth.default.publicKey | string | `nil` | public key for checking the validity of jwt tokens, set this when type=jwt |
 | dataplanes.dataplane.auth.default.register | bool | `false` | controls whether this service should be registered as the default EDC authentication service globally |
 | dataplanes.dataplane.auth.default.type | string | `"api-key"` | the type of the default authentication service (api-key, jwt or composite) |
-| dataplanes.dataplane.auth.default.vault-key | string | `nil` | vault key for obtaining the API key, Set this when type=api-key or use the api-code property instead |
+| dataplanes.dataplane.auth.default.vaultKey | string | `nil` | vault key for obtaining the API key, Set this when type=api-key or use the api-code property instead |
 | dataplanes.dataplane.autoscaling.enabled | bool | `false` | Enables [horizontal pod autoscaling](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) |
 | dataplanes.dataplane.autoscaling.maxReplicas | int | `100` | Maximum replicas if resource consumption exceeds resource threshholds |
 | dataplanes.dataplane.autoscaling.minReplicas | int | `1` | Minimal replicas if resource consumption falls below resource threshholds |

--- a/charts/agent-connector/README.md
+++ b/charts/agent-connector/README.md
@@ -20,14 +20,14 @@
 
 # agent-connector
 
-![Version: 1.9.5-SNAPSHOT](https://img.shields.io/badge/Version-1.9.5--SNAPSHOT-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.9.5-SNAPSHOT](https://img.shields.io/badge/AppVersion-1.9.5--SNAPSHOT-informational?style=flat-square)
+![Version: 1.9.7-SNAPSHOT](https://img.shields.io/badge/Version-1.9.7--SNAPSHOT-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.9.5-SNAPSHOT](https://img.shields.io/badge/AppVersion-1.9.5--SNAPSHOT-informational?style=flat-square)
 
 A Helm chart for an Agent-Enabled Tractus-X Eclipse Data Space Connector. The connector deployment consists of two runtime consists of a
 Control Plane and a Data Plane. Note that _no_ external dependencies such as a PostgreSQL database and HashiCorp Vault are included.
 
 This chart is intended for use with an _existing_ PostgreSQL database and an _existing_ HashiCorp Vault.
 
-**Homepage:** <https://github.com/eclipse-tractusx/knowledge-agents-edc/tree/main/charts/agent-connector>
+**Homepage:** <https://github.com/eclipse-tractusx/knowledge-agents-edc/>
 
 ## Setting up SSI
 
@@ -68,8 +68,14 @@ Combined, run this shell command to start the in-memory Tractus-X EDC runtime:
 
 ```shell
 helm repo add eclipse-tractusx https://eclipse-tractusx.github.io/charts/dev
-helm install my-release eclipse-tractusx/agent-connector --version 1.9.5-SNAPSHOT
+helm install my-release eclipse-tractusx/agent-connector --version 1.9.7-SNAPSHOT
 ```
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| Tractus-X Knowledge Agents Team |  |  |
 
 ## Source Code
 
@@ -197,6 +203,15 @@ helm install my-release eclipse-tractusx/agent-connector --version 1.9.5-SNAPSHO
 | dataplanes.dataplane.agent.services.deny | string | `"http://.*"` | A regular expression which outgoing service URLs must not match (unless overwritten by a specific asset property) |
 | dataplanes.dataplane.agent.skillcontract | string | `"Contract?partner=Skill"` | Names the visible contract under which new skills are published (if not otherwise specified) |
 | dataplanes.dataplane.agent.synchronization | int | `-1` | The synchronization interval in ms to update the federated data catalogue |
+| dataplanes.dataplane.auth | object | `{"default":{"api-code":69609650,"check-expiry":true,"context":"default","public-key":null,"register":false,"type":"api-key","vault-key":null}}` | Data Plane Authentication using the KA-EDC-AUTH-JWT extension, any entry has a type (api-key, jwt or composite) and a (set of) path contexts (see endpoints) followed by type-specific entries |
+| dataplanes.dataplane.auth.default | object | `{"api-code":69609650,"check-expiry":true,"context":"default","public-key":null,"register":false,"type":"api-key","vault-key":null}` | the default authentication service |
+| dataplanes.dataplane.auth.default.api-code | int | `69609650` | specific api-code associated to the default api-key 'Hello', Change this when type=api-key or use the vault-key property instead |
+| dataplanes.dataplane.auth.default.check-expiry | bool | `true` | controls whether the expiry date of jwt tokens is checked when type=jwt |
+| dataplanes.dataplane.auth.default.context | string | `"default"` | the context(s) of the default authentication service separated by commas |
+| dataplanes.dataplane.auth.default.public-key | string | `nil` | public key for checking the validity of jwt tokens, set this when type=jwt |
+| dataplanes.dataplane.auth.default.register | bool | `false` | controls whether this service should be registered as the default EDC authentication service globally |
+| dataplanes.dataplane.auth.default.type | string | `"api-key"` | the type of the default authentication service (api-key, jwt or composite) |
+| dataplanes.dataplane.auth.default.vault-key | string | `nil` | vault key for obtaining the API key, Set this when type=api-key or use the api-code property instead |
 | dataplanes.dataplane.autoscaling.enabled | bool | `false` | Enables [horizontal pod autoscaling](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) |
 | dataplanes.dataplane.autoscaling.maxReplicas | int | `100` | Maximum replicas if resource consumption exceeds resource threshholds |
 | dataplanes.dataplane.autoscaling.minReplicas | int | `1` | Minimal replicas if resource consumption falls below resource threshholds |
@@ -281,6 +296,7 @@ helm install my-release eclipse-tractusx/agent-connector --version 1.9.5-SNAPSHO
 | dataplanes.dataplane.volumes | list | `[]` | [volume](https://kubernetes.io/docs/concepts/storage/volumes/) directories |
 | fullnameOverride | string | `""` |  |
 | imagePullSecrets | list | `[]` | Existing image pull secret to use to [obtain the container image from private registries](https://kubernetes.io/docs/concepts/containers/images/#using-a-private-registry) |
+| imageRegistry | string | `"docker.io/"` | Image registry to use |
 | install.postgresql | bool | `false` |  |
 | install.vault | bool | `false` |  |
 | nameOverride | string | `""` |  |

--- a/charts/agent-connector/README.md.gotmpl
+++ b/charts/agent-connector/README.md.gotmpl
@@ -28,6 +28,20 @@
 
 {{ template "chart.homepageLine" . }}
 
+## Setting up your BPNL and the Control Plane's Management API Key
+
+The secure API-Key that is shared between control and agent plane is configured in the following property:
+- 'controlplane.endpoints.management.authKey': Cleartext API Key as used to secure the control planes management api (and is used by the agent plane to synchronize assets and negotiate calls).
+
+You should set your BPNL in the folloing property:
+- 'participant.id': 'BPNL' followed by 12 alphanumerical characters as handed out to you during onboarding.
+
+## Setting up Hashicorp Vault
+
+You should set your BPNL in the folloing property:
+- 'vault.hashicorp.url': URL of the vault API
+- 'vault.hashicorp.token': A valid, generated access token.
+
 ## Setting up SSI
 
 ### Preconditions
@@ -44,7 +58,6 @@
 - store your KeyCloak client secret in the HashiCorp vault. The exact procedure will depend on your deployment of HashiCorp Vault and
   is out of scope of this document. But by default, Tractus-X EDC expects to find the secret under `secret/client-secret`.
 
-
 ### Configure the chart
 
 Be sure to provide the following configuration entries to your Tractus-X EDC Helm chart:
@@ -54,7 +67,22 @@ Be sure to provide the following configuration entries to your Tractus-X EDC Hel
 - `controlplane.ssi.oauth.client.id`: client ID for KeyCloak
 - `controlplane.ssi.oauth.client.secretAlias`: the alias under which the client secret is stored in the vault. Defaults to `client-secret`.
 
-Be sure to adapt the agent configuration 
+## Setting up the Agent Planes
+
+Make sure to adapt the Agent Plane's application-facing endpoint security:
+- 'dataplanes.agentplane.auth.default.type': The type of authentication service to use (defaults to api-key, you could also use jwt)
+- 'dataplanes.agentplane.auth.default.apiCode': If type is api-key, this is the hash of the accepted api key
+- 'dataplanes.agentplane.auth.default.vaultKey': If type is api-key, this is the key where the api key can be retrieved from the configured vault
+- 'dataplanes.agentplane.auth.default.publicKey': If type is jwt, this is a url where the public key to verify token with can be found
+- 'dataplanes.agentplane.auth.default.checkExpiry': If type is jwt, determines whether token expiry is checked (default: true)
+
+Be sure to review the Agent Plane's service delegation filter which regulates with which external Agent's (SERVICE) this instance may interact. These properties form typical allow/deny conditions. Because of the nature of SPARQL, interacting with such a service may not only mean to import data from there, but you must take into account bound variables in the SERVICE contexts are also exported to there. So you should be rather prohibitive here.  
+- 'dataplanes.agentplane.agent.services.allow': A regular expression of allowed Agent/Sparql SERVICE contexts in the default graph (federated data catalogue). The default graph only contains meta-data and can only be invoked by any in-house application, so usually you can be a bit more relaxed on this level. For example, you might be tempted to allow to mix your application logic and data with some universal service, such as Wikidata.
+- 'dataplanes.agentplane.agent.services.deny': A regular expression of denied outgoing Agent/Sparql SERVICE contexts in the default graph (federated data catalogue). Typically you would restrict any unsecured http call by this properties.
+- 'dataplanes.agentplane.agent.services.assets.allow': A regular expression of allowed Agent/Sparql SERVICE contexts when inside a data graph/asset (unless there are more specific settings in the asset itself). Since this affects how you can spice up your business data, you would only allow connections to trusted business partners connectors.
+- 'dataplanes.agentplane.agent.services.assets.deny': A regular expression of denied Agent/Sparql SERVICE contexts. Use this to filter out unsecure protocols such as edc and http as well as to implement blacklists.
+
+Be sure to adapt the agent configuration
 - 'dataplanes.agentplane.configs.dataspace.ttl': additional TTL text resource which lists the partner BPNs and their associated connectors.
 - 'dataplanes.agentplane.agent.maxbatchsize': Should be restricted to a smaller number of tuples (10-100) if you intend to communicate over larger datasets.
 - 'dataplanes.agentplane.agent.synchronization': Should be set to a positive number of seconds to activate the automatic synchronization of federated data catalogues.

--- a/charts/agent-connector/templates/deployment-dataplane.yaml
+++ b/charts/agent-connector/templates/deployment-dataplane.yaml
@@ -129,7 +129,40 @@ spec:
             - name: "EDC_DATAPLANE_TOKEN_VALIDATION_ENDPOINT"
               value: {{ include "txdc.controlplane.url.validation" $root}}
 
+            ###################
+            # AUTH (JWT)      #
+            ###################
+          {{- if $dataplane.auth }}
+          {{- range $auth, $authDef := $dataplane.auth }} 
+            - name: {{ printf "TRACTUSX_AUTH_%s_TYPE" (upper $auth) | quote }}
+              value: {{ $authDef.type | required "Authentication Service needs a type" | quote }}
+            - name: {{ printf "TRACTUSX_AUTH_%s_PATHS" (upper $auth) | quote }}
+              value: {{ $authDef.context | required "Authentication Service needs a context" | quote }}
+          {{- if $authDef.register }}   
+            - name: {{ printf "TRACTUSX_AUTH_%s_REGISTER" (upper $auth) | quote }}
+              value: {{ $authDef.register | quote }}
+          {{- end }}
+          {{- if $authDef.apiCode }}   
+            - name: {{ printf "TRACTUSX_AUTH_%s_API_CODE" (upper $auth) | quote }}
+              value: {{ $authDef.apiCode | quote }}
+          {{- end }}
+          {{- if $authDef.vaultKey }}   
+            - name: {{ printf "TRACTUSX_AUTH_%s_VAULT_KEY" (upper $auth) | quote }}
+              value: {{ $authDef.vaultKey | quote }}
+          {{- end }}
+          {{- if $authDef.publicKey }}   
+            - name: {{ printf "TRACTUSX_AUTH_%s_PUBLICKEY" (upper $auth) | quote }}
+              value: {{ $authDef.publicKey | quote }}
+          {{- end }}
+          {{- if $authDef.checkExpiry }}   
+            - name: {{ printf "TRACTUSX_AUTH_%s_CHECKEXPIRY" (upper $auth) | quote }}
+              value: {{ $authDef.checkExpiry | quote }}
+          {{- end }}
+          {{- end }}
+          {{- end }}
+
           {{- if $dataplane.endpoints.callback }}
+
             ###################
             # AGENT CALLBACK  #
             ###################
@@ -150,6 +183,7 @@ spec:
           {{- end }}
 
           {{- if $dataplane.agent.default }}
+
             ###############
             # AGENT INIT  #
             ###############
@@ -160,6 +194,7 @@ spec:
           {{- end }}
           
           {{- if $dataplane.agent.services }}
+
             ###################
             # AGENT SERVICES #
             ###################
@@ -184,6 +219,7 @@ spec:
           {{- end }}
 
           {{- if $dataplane.agent.connectors }}
+
             ###################
             # AGENT SYNC      #
             ###################

--- a/charts/agent-connector/values.yaml
+++ b/charts/agent-connector/values.yaml
@@ -364,6 +364,24 @@ dataplanes:
       metrics:
         port: 9090
         path: /metrics
+    # -- Data Plane Authentication using the KA-EDC-AUTH-JWT extension, any entry has a type (api-key, jwt or composite) and a (set of) path contexts (see endpoints) followed by type-specific entries
+    auth:
+      # -- the default authentication service
+      default:
+        # -- the type of the default authentication service (api-key, jwt or composite)
+        type: api-key
+        # -- the context(s) of the default authentication service separated by commas
+        context: default
+        # -- controls whether this service should be registered as the default EDC authentication service globally
+        register: false
+        # -- specific api-code associated to the default api-key 'Hello', Change this when type=api-key or use the vault-key property instead. Althugh this represents a number, remember to use quotes not to confuse rendering into the chart.
+        apiCode: "69609650"
+        # -- vault key for obtaining the API key, Set this when type=api-key or use the api-code property instead
+        vaultKey:
+        # -- public key for checking the validity of jwt tokens, set this when type=jwt
+        publicKey:
+        # -- controls whether the expiry date of jwt tokens is checked when type=jwt
+        checkExpiry: true
     aws:
       endpointOverride: ""
       accessKeyId: ""

--- a/charts/config/chart-testing-config.yaml
+++ b/charts/config/chart-testing-config.yaml
@@ -18,7 +18,7 @@
 ---
 # Config for testing charts
 validate-maintainers: false
-helm-extra-set-args: "--set=imageRegistry=kind-registry:5000/"
+helm-extra-args: "--set imageRegistry=kind-registry:5000/ --set controlplane.endpoints.management.authKey=test --set vault.hashicorp.token=DUMMY --set participant.id=BPNL0000000DUMMY --set vault.azure.client=AZURE_CLIENT --set vault.azure.tenant=AZURE_TENANT --set vault.azure.name=AZURE_NAME"
 chart-repos:
  - helm=https://helm.releases.hashicorp.com
  - bitnami=https://charts.bitnami.com/bitnami

--- a/common/README.md
+++ b/common/README.md
@@ -28,7 +28,7 @@ may be used in any EDC plane/container for enabling a secure application/end use
 
 It consists of
 
-- [JWT Based Authentication](auth-jwt)
+- [(Not Only) JWT Based Authentication Stack](auth-jwt)
 
 ## Getting Started
 

--- a/common/auth-jwt/README.md
+++ b/common/auth-jwt/README.md
@@ -17,25 +17,53 @@
  * SPDX-License-Identifier: Apache-2.0
 -->
 
-# Tractus-X Knowledge Agents (Hey Catena!) EDC JWT Auth Extension
+# Tractus-X Knowledge Agents (Not Only) JWT-Based Authentication Stack EDC Extension (KA-EDC-JWT-AUTH)
 
 This folder hosts an authentication extension to the [Eclipse Dataspace Connector (EDC)](https://projects.eclipse.org/projects/technology.dataspaceconnector).
 
-It allows to configure and build composite/stacked authentication services including the validation of JWT tokens versus
-public keys.
+It allows to configure and build [Authentication Services](https://github.com/eclipse-edc/Connector/blob/main/spi/common/auth-spi/src/main/java/org/eclipse/edc/api/auth/spi/AuthenticationService.java), such as the validation of 
+- [API Keys](src/main/java/org/eclipse/tractusx/edc/auth/ApiKeyAuthenticationService.java)
+- [JWT Tokens](src/main/java/org/eclipse/tractusx/edc/auth/JwtAuthenticationService.java) or 
+- [Combinations of Authentication Services](src/main/java/org/eclipse/tractusx/edc/auth/CompositeAuthenticationService.java)
 
-It allows to install authentication filters backed by those authentication services to
-various web service contexts.
+It allows to install authentication filters that are backed by those authentication services into various web service contexts 
+(in addition to or in place of other authentication mechanisms).
+
+## How to enable this extension
+
+Add the following dependency to your EDC artifact pom:
+
+```xml
+        <dependency>
+            <groupId>org.eclipse.tractusx.agents.edc</groupId>
+            <artifactId>auth-jwt</artifactId>
+            <version>1.9.5-SNAPSHOT</version>
+        </dependency>
+```
+
+and the following repo to your repositories section
+
+```xml
+    <repository>
+      <id>github</id>
+      <name>Tractus-X KA-EDC Maven Repository on Github</name>
+      <url>https://maven.pkg.github.com/eclipse-tractusx/knowledge-agents-edc</url>
+    </repository> 
+```
 
 ## How to configure this extension
 
-The following is a list of configuration objects and properties that you might set in the corresponding mounted config files
+The following is a list of configuration properties (or environment variables) that you might set. The environment variables key is obtained by upper-casing the property name and replacing dots with underscores, e.g. 'cx.agent.asset.file' becomes 'CX_AGENT_ASSET_FILE'. When the property is marked as 'X' in the 'Required' column, the extension would not work when it is not set. When the property is marked as '(X)' it means that the extension would work, but with restrictions. When the property is marked as 'L' in the 'List' column, it accepts a comma-separated list of values. When the property is marked as '*' in the 'List' column, then this indicates that you may have multiple instances of the property (by replacing the <id> in the property name by a unique id).
 
-| SETTING                                         | Required | Default/Example                                                | Description                                                                                                                             | 
-|-------------------------------------------------|----------|----------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------|
-| tractusx.auth.<name>.type                       | no       | jwt                                        |  Introduces a new authentication filter                                                                          |   
-| tractusx.auth.<name>.publickey                  | yes, if jwt       |  https://keycloak.instance/auth/realms/REALM/protocol/openid-connect/certs                                      |  download url  for public cert of REALM                                                                       |   
-| tractusx.auth.<name>.register                   | no      |  true                                      |   Whether the filter should be registered in the EDC list                                                                     |   
-| tractusx.auth.<name>.checkexpiry                | no, if jwt       |  true                                      |   Whether tokens should be checked for expiry                                                                     |   
-| tractusx.auth.<name>.paths                | no, if jwt       |  default                                      |   A list of paths in the token claims which should be checked upon existance                                                                    |   
+| SETTING                                     | Required                  | Default/Example                                                           | Description                                                                                                                                                | 
+|---------------------------------------------|---------------------------|---------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| tractusx.auth.<name>.type                   | no                        | jwt                                                                       | Introduces a new authentication filter ('jwt', 'api-key' or 'composite')                                                                                   |   
+| tractusx.auth.<name>.register               | no                        | true                                                                      | Whether the filter should be registered in the EDC list                                                                                                    |   
+| tractusx.auth.<name>.paths                  | no                        | default                                                                   | A list of web service paths which should be secured using that service                                                                                     |   
+| tractusx.auth.<name>.publickey              | yes, if type = 'jwt'      | https://keycloak.instance/auth/realms/REALM/protocol/openid-connect/certs | download url  for public cert of REALM                                                                                                                     |   
+| tractusx.auth.<name>.checkexpiry            | no, if type = 'jwt'       | true                                                                      | Whether tokens should be checked for expiry                                                                                                                |   
+| tractusx.auth.<name>.api-code               | no, if type = 'api-key'   | 69609650                                                                  | Hashcode for the api key (here :'Hello') - alternatively use vault-key                                                                                     |   
+| tractusx.auth.<name>.vault-key              | no, if type = 'api-key'   | edc-api-key                                                               | Key for the api-key in the configured vault - alternatively use api-code                                                                                   |   
+| tractusx.auth.<name>.mode                   | no, if type = 'composite' | ALL                                                                       | Determines the mode of composition, 'ALL' means that all subservices need to be successful, 'ONE' means that one of the subservices needs to be successful |   
+| tractusx.auth.<name>.service.<subname>.type | no, if type = 'composite' | api-key                                                                   | Adds a sub-service to a composite authentication service                                                                                                   |   
 

--- a/common/auth-jwt/src/main/java/org/eclipse/tractusx/edc/auth/ApiKeyAuthenticationService.java
+++ b/common/auth-jwt/src/main/java/org/eclipse/tractusx/edc/auth/ApiKeyAuthenticationService.java
@@ -1,0 +1,63 @@
+// Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License, Version 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+package org.eclipse.tractusx.edc.auth;
+
+import org.eclipse.edc.api.auth.spi.AuthenticationService;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Implements an Api-Key Based Authentication Service
+ * we use a hashcode based comparison not to store a secret
+ * in clear text in memory
+ */
+public class ApiKeyAuthenticationService implements AuthenticationService {
+    public static String AUTHENTICATION_HEADER="x-api-key";
+    final protected int reference;
+
+    public ApiKeyAuthenticationService(int reference) {
+        this.reference=reference;
+    }
+
+    @Override
+    public boolean isAuthenticated(Map<String, List<String>> map) {
+        return map.entrySet().stream()
+                .filter( e->e.getKey().equalsIgnoreCase(AUTHENTICATION_HEADER))
+                .flatMap( e->e.getValue().stream().map( v -> reference==v.hashCode()))
+                .anyMatch(b->b);
+    }
+
+    /**
+     * a builder for api key authentication services
+     */
+    public static class Builder {
+        protected int reference;
+
+        public Builder() {
+        }
+
+        public Builder setReference(int reference) {
+            this.reference=reference;
+            return this;
+        }
+
+        public ApiKeyAuthenticationService build() {
+            return new ApiKeyAuthenticationService(reference);
+        }
+    }
+}

--- a/common/auth-jwt/src/main/java/org/eclipse/tractusx/edc/auth/CompositeAuthenticationMode.java
+++ b/common/auth-jwt/src/main/java/org/eclipse/tractusx/edc/auth/CompositeAuthenticationMode.java
@@ -1,0 +1,31 @@
+// Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License, Version 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+package org.eclipse.tractusx.edc.auth;
+
+/**
+ * lists the composite authentication modes
+ */
+public enum CompositeAuthenticationMode {
+    /**
+     * all sub services must match, if there is none results to true
+     */
+    ALL,
+    /**
+     * one sub service must match, if there is none results to false
+     */
+    ONE
+}

--- a/common/auth-jwt/src/test/java/org/eclipse/tractusx/edc/auth/ApiKeyAuthenticationServiceTest.java
+++ b/common/auth-jwt/src/test/java/org/eclipse/tractusx/edc/auth/ApiKeyAuthenticationServiceTest.java
@@ -1,0 +1,61 @@
+// Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License, Version 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+package org.eclipse.tractusx.edc.auth;
+
+import com.nimbusds.jose.JOSEException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Tests the api-key service
+ */
+
+public class ApiKeyAuthenticationServiceTest {
+    ApiKeyAuthenticationService service;
+
+    String key;
+
+    @BeforeEach
+    public void initialize() throws JOSEException {
+        key= UUID.randomUUID().toString();
+        service=new ApiKeyAuthenticationService(key.hashCode());
+    }
+
+    @Test
+    public void testValidKey() {
+        var headers=Map.of("x-api-key", List.of(key));
+        assertTrue(service.isAuthenticated(headers),"Could not authenticate using valid api key");
+    }
+
+    @Test
+    public void testInvalidKey() {
+        var headers=Map.of("x-api-key", List.of(UUID.randomUUID().toString()));
+        assertFalse(service.isAuthenticated(headers),"Could authenticate using invalid key");
+    }
+
+    @Test
+    public void testInvalidHeader() {
+        var headers=Map.of("api-key", List.of(key));
+        assertFalse(service.isAuthenticated(headers),"Could authenticate using invalid header");
+    }
+
+}

--- a/common/auth-jwt/src/test/java/org/eclipse/tractusx/edc/auth/JwtAuthenticationServiceTest.java
+++ b/common/auth-jwt/src/test/java/org/eclipse/tractusx/edc/auth/JwtAuthenticationServiceTest.java
@@ -34,6 +34,9 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * tests the jwt service
+ */
 public class JwtAuthenticationServiceTest {
     ObjectMapper om;
 
@@ -43,6 +46,18 @@ public class JwtAuthenticationServiceTest {
 
     String token;
     String token2;
+
+    public org.eclipse.tractusx.edc.auth.JwtAuthenticationService getService() {
+        return service;
+    }
+
+    public String getToken2() {
+        return token2;
+    }
+
+    public String getToken() {
+        return token;
+    }
 
     @BeforeEach
     public void initialize() throws JOSEException {
@@ -79,6 +94,12 @@ public class JwtAuthenticationServiceTest {
     @Test
     public void testValidJwtToken() {
         var headers=Map.of("Authorization", List.of("Bearer "+token));
+        assertTrue(service.isAuthenticated(headers),"Could not authenticate using valid token");
+    }
+
+    @Test
+    public void testValidLowercaseJwtToken() {
+        var headers=Map.of("authorization", List.of("Bearer "+token));
         assertTrue(service.isAuthenticated(headers),"Could not authenticate using valid token");
     }
 


### PR DESCRIPTION
## WHAT

Provides a useful default authentication configuration (based on api-key hashes) which can be easily adopted, e.g. to use jwt-based authentication.

## WHY

Security Assessment Threat Mitigation

## FURTHER NOTES

Currently, we need to copy the EDC charts, because the helm value/template structure is significantly changed by introducing multiple dataplanes (of which the agent plane is one option). A reference to the original chart has been added right into the documentation.

The chartlint workflow already looks like the final upgrade workflow, but since the EDC charts are always depending on some external service (hashicorp, azure-vault), we cannot easily deploy (and hence upgrade-test) the charts.

Closes #24 
Explains but not closes #26