### PR TITLE
fix: #46 do not use build-args in the dockerfiles, else we risk corrupt images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,6 +89,15 @@ jobs:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # Run Maven Deploy (if either running on main or a version tag on a fork)
+      - name: Deploy Java via Maven
+        if: ${{ github.repository == 'catenax-ng/tx-knowledge-agents-edc' && ( github.ref == 'refs/heads/main' ||  startsWith(github.ref, 'refs/tags/v')) }}
+        run: |
+          ./mvnw -s settings.xml deploy -Pwith-docker-image -Drepo=ghcr.io/catenax-ng/tx-knowledge-agents-edc
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       # Run Maven Install (otherwise)
       - name: Build Java via Maven
         if: ${{ github.repository != 'eclipse-tractusx/knowledge-agents-edc' || ( github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/v')) }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,10 +41,6 @@ on:
   # Manual workflow trigger
   workflow_dispatch:
 
-# the docker registry and namespace
-env:
-  IMAGE_NAMESPACE: "tractusx"
-
 # If build is triggered several times, e.g., through subsequent pushes
 # into the same PR, cancel the previous runs, see below
 concurrency:
@@ -62,6 +58,15 @@ jobs:
     strategy:
       fail-fast: false
     steps:
+
+      # Determine the right target docker repo
+      - name: Check github repository and set docker repo
+        id: set-docker-repo
+        run: |
+          [ "${{ github.repository }}" == "eclipse-tractusx/knowledge-agents-edc" ] && echo "REPO=tractusx" >> $GITHUB_OUTPUT
+          [ "${{ github.repository }}" != "eclipse-tractusx/knowledge-agents-edc" ] && echo "REPO=ghcr.io/${{ github.repository }}" >> $GITHUB_OUTPUT
+          exit 0
+
       # Get the Code
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -71,7 +76,7 @@ jobs:
       # Setup build environment
       - uses: ./.github/actions/setup-java
 
-      # Enabled deployment access (if either running on main or a version tag on eclipse-tractusx)
+      # Enable deployment access (if either running on main or a version tag on eclipse-tractusx)
       - name: Login to GitHub Container Registry
         if: ${{ github.repository == 'eclipse-tractusx/knowledge-agents-edc' && ( github.ref == 'refs/heads/main' ||  startsWith(github.ref, 'refs/tags/v')) }}
         uses: docker/login-action@v2
@@ -91,16 +96,16 @@ jobs:
 
       # Run Maven Deploy (if either running on main or a version tag on a fork)
       - name: Deploy Java via Maven
-        if: ${{ github.repository == 'catenax-ng/tx-knowledge-agents-edc' && ( github.ref == 'refs/heads/main' ||  startsWith(github.ref, 'refs/tags/v')) }}
+        if: ${{ github.repository != 'eclipse-tractusx/knowledge-agents-edc' && ( github.ref == 'refs/heads/main' ||  startsWith(github.ref, 'refs/tags/v')) }}
         run: |
-          ./mvnw -s settings.xml deploy -Pwith-docker-image -Drepo=ghcr.io/catenax-ng/tx-knowledge-agents-edc -DaltDeploymentRepository=github::default::https://maven.pkg.github.com/catenax-ng/tx-knowledge-agents-edc
+          ./mvnw -s settings.xml deploy -Pwith-docker-image -Drepo=${{ steps.set-docker-repo.outputs.REPO }} -DaltDeploymentRepository=github::default::https://maven.pkg.github.com/${{ github.repository }}
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Run Maven Install (otherwise)
       - name: Build Java via Maven
-        if: ${{ (github.repository != 'eclipse-tractusx/knowledge-agents-edc' && github.repository != 'catenax-ng/tx-knowledge-agents-edc') || ( github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/v')) }}
+        if: ${{ ( github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/v')) }}
         run: |
           ./mvnw -s settings.xml install
         env:
@@ -113,7 +118,7 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: |
-            ${{ env.IMAGE_NAMESPACE }}/agentplane-hashicorp
+            ${{ steps.set-docker-repo.outputs.REPO }}/agentplane-hashicorp
           # Automatically prepare image tags; See action docs for more examples.
           # semver patter will generate tags like these for example :1 :1.2 :1.2.3
           tags: |
@@ -143,7 +148,7 @@ jobs:
           readme-filepath: agent-plane/agentplane-hashicorp/README.md
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
-          repository: ${{ env.IMAGE_NAMESPACE }}/agentplane-hashicorp
+          repository: ${{ steps.set-docker-repo.outputs.REPO }}/agentplane-hashicorp
 
       # Create SemVer or ref tags dependent of trigger event
       - name: Docker Meta Agent Plane Azure Vault
@@ -151,7 +156,7 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: |
-            ${{ env.IMAGE_NAMESPACE }}/agentplane-azure-vault
+            ${{ steps.set-docker-repo.outputs.REPO }}/agentplane-azure-vault
           # Automatically prepare image tags; See action docs for more examples.
           # semver patter will generate tags like these for example :1 :1.2 :1.2.3
           tags: |
@@ -181,4 +186,4 @@ jobs:
           readme-filepath: agent-plane/agentplane-azure-vault/README.md
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
-          repository: ${{ env.IMAGE_NAMESPACE }}/agentplane-azure-vault
+          repository: ${{ steps.set-docker-repo.outputs.REPO }}/agentplane-azure-vault

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,14 +93,14 @@ jobs:
       - name: Deploy Java via Maven
         if: ${{ github.repository == 'catenax-ng/tx-knowledge-agents-edc' && ( github.ref == 'refs/heads/main' ||  startsWith(github.ref, 'refs/tags/v')) }}
         run: |
-          ./mvnw -s settings.xml deploy -Pwith-docker-image -Drepo=ghcr.io/catenax-ng/tx-knowledge-agents-edc
+          ./mvnw -s settings.xml deploy -Pwith-docker-image -Drepo=ghcr.io/catenax-ng/tx-knowledge-agents-edc -DaltDeploymentRepository=github::default::https://maven.pkg.github.com/catenax-ng/tx-knowledge-agents-edc
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Run Maven Install (otherwise)
       - name: Build Java via Maven
-        if: ${{ github.repository != 'eclipse-tractusx/knowledge-agents-edc' || ( github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/v')) }}
+        if: ${{ (github.repository != 'eclipse-tractusx/knowledge-agents-edc' && github.repository != 'catenax-ng/tx-knowledge-agents-edc') || ( github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/v')) }}
         run: |
           ./mvnw -s settings.xml install
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,8 +63,8 @@ jobs:
       - name: Check github repository and set docker repo
         id: set-docker-repo
         run: |
-          [ "${{ github.repository }}" == "eclipse-tractusx/knowledge-agents-edc" ] && echo "REPO=tractusx" >> $GITHUB_OUTPUT
-          [ "${{ github.repository }}" != "eclipse-tractusx/knowledge-agents-edc" ] && echo "REPO=ghcr.io/${{ github.repository }}" >> $GITHUB_OUTPUT
+          if [ "${{ github.repository }}" == "eclipse-tractusx/knowledge-agents-edc" ]; then echo "REGISTRY=docker.io" >> $GITHUB_OUTPUT; else echo "REGISTRY=ghcr.io" >> $GITHUB_OUTPUT;  fi          
+          if [ "${{ github.repository }}" == "eclipse-tractusx/knowledge-agents-edc" ]; then echo "REPO=tractusx" >> $GITHUB_OUTPUT; else echo "REPO=ghcr.io/${{ github.repository }}" >> $GITHUB_OUTPUT;  fi
           exit 0
 
       # Get the Code
@@ -76,29 +76,21 @@ jobs:
       # Setup build environment
       - uses: ./.github/actions/setup-java
 
-      # Enable deployment access (if either running on main or a version tag on eclipse-tractusx)
+      # Enable deployment access (on main branch and version tags only)
       - name: Login to GitHub Container Registry
-        if: ${{ github.repository == 'eclipse-tractusx/knowledge-agents-edc' && ( github.ref == 'refs/heads/main' ||  startsWith(github.ref, 'refs/tags/v')) }}
+        if: ${{ ( github.ref == 'refs/heads/main' ||  startsWith(github.ref, 'refs/tags/v')) }}
         uses: docker/login-action@v2
         with:
+          registry: ${{ steps.set-docker-repo.outputs.REGISTRY }}
           # Use existing DockerHub credentials present as secrets
-          username: ${{ secrets.DOCKER_HUB_USER }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+          username: ${{ secrets.DOCKER_HUB_USER || github.actor }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN || secrets.GITHUB_TOKEN }}
 
-      # Run Maven Deploy (if either running on main or a version tag on eclipse-tractusx)
+      # Run Maven Deploy (if either running on main or a version tag)
       - name: Deploy Java via Maven
-        if: ${{ github.repository == 'eclipse-tractusx/knowledge-agents-edc' && ( github.ref == 'refs/heads/main' ||  startsWith(github.ref, 'refs/tags/v')) }}
+        if: ${{ ( github.ref == 'refs/heads/main' ||  startsWith(github.ref, 'refs/tags/v')) }}
         run: |
-          ./mvnw -s settings.xml deploy
-        env:
-          GITHUB_ACTOR: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      # Run Maven Deploy (if either running on main or a version tag on a fork)
-      - name: Deploy Java via Maven
-        if: ${{ github.repository != 'eclipse-tractusx/knowledge-agents-edc' && ( github.ref == 'refs/heads/main' ||  startsWith(github.ref, 'refs/tags/v')) }}
-        run: |
-          ./mvnw -s settings.xml deploy -Pwith-docker-image -Drepo=${{ steps.set-docker-repo.outputs.REPO }} -DaltDeploymentRepository=github::default::https://maven.pkg.github.com/${{ github.repository }}
+          ./mvnw -s settings.xml deploy -DaltDeploymentRepository=github::default::https://maven.pkg.github.com/${{ github.repository }}
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -136,7 +128,7 @@ jobs:
           context: agent-plane/agentplane-hashicorp
           file: agent-plane/agentplane-hashicorp/src/main/docker/Dockerfile
           # Build image for verification purposes on every trigger event. Only push if event is not a PR
-          push: ${{ github.repository == 'eclipse-tractusx/knowledge-agents-edc'  && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) }}
+          push: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) }}
           tags: ${{ steps.meta-hash.outputs.tags }}
           labels: ${{ steps.meta-hash.outputs.labels }}
 
@@ -174,7 +166,7 @@ jobs:
           context: agent-plane/agentplane-azure-vault/.
           file: agent-plane/agentplane-azure-vault/src/main/docker/Dockerfile
           # Build image for verification purposes on every trigger event. Only push if event is not a PR
-          push: ${{ github.repository == 'eclipse-tractusx/knowledge-agents-edc'  && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) }}
+          push: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) }}
           tags: ${{ steps.meta-azr.outputs.tags }}
           labels: ${{ steps.meta-azr.outputs.labels }}
 
@@ -184,6 +176,6 @@ jobs:
         uses: peter-evans/dockerhub-description@v3
         with:
           readme-filepath: agent-plane/agentplane-azure-vault/README.md
-          username: ${{ secrets.DOCKER_HUB_USER }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+          username: ${{ secrets.DOCKER_HUB_USER || github.actor }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN || secrets.GITHUB_TOKEN }}
           repository: ${{ steps.set-docker-repo.outputs.REPO }}/agentplane-azure-vault

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -44,8 +44,8 @@ jobs:
       - name: Resolve git 7-chars sha
         id: git-sha7
         run: |
+          echo "SHA7=1.9.8" >> $GITHUB_OUTPUT
           [ "${{ github.repository }}" == "eclipse-tractusx/knowledge-agents-edc" ] && echo "SHA7=sha-${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
-          [ "${{ github.repository }}" != "eclipse-tractusx/knowledge-agents-edc" ] && echo "SHA7=1.9.8" >> $GITHUB_OUTPUT
           
   trivy-analyze-config:
     runs-on: ubuntu-latest
@@ -90,20 +90,21 @@ jobs:
       - name: Check github repository and set docker repo
         id: set-docker-repo
         run: |
-          [ "${{ github.repository }}" == "eclipse-tractusx/knowledge-agents-edc" ] && echo "REPO=tractusx" >> $GITHUB_OUTPUT
-          [ "${{ github.repository }}" != "eclipse-tractusx/knowledge-agents-edc" ] && echo "REPO=ghcr.io/${{ github.repository }}" >> $GITHUB_OUTPUT
+          if [ "${{ github.repository }}" == "eclipse-tractusx/knowledge-agents-edc" ]; then echo "REGISTRY=docker.io" >> $GITHUB_OUTPUT; else echo "REGISTRY=ghcr.io" >> $GITHUB_OUTPUT;  fi          
+          if [ "${{ github.repository }}" == "eclipse-tractusx/knowledge-agents-edc" ]; then echo "REPO=tractusx" >> $GITHUB_OUTPUT; else echo "REPO=ghcr.io/${{ github.repository }}" >> $GITHUB_OUTPUT;  fi
           exit 0
 
       - uses: actions/checkout@v3.5.2
 
-      # Enable repository access (if either running on main or a version tag on eclipse-tractusx)
+      # Enable repository access (on main branch and version tags only)
       - name: Login to GitHub Container Registry
+        if: ${{ ( github.ref == 'refs/heads/main' ||  startsWith(github.ref, 'refs/tags/v')) }}
         uses: docker/login-action@v2
-        if: ${{ github.repository == 'eclipse-tractusx/knowledge-agents-edc' && ( github.ref == 'refs/heads/main' ||  startsWith(github.ref, 'refs/tags/v')) }}
         with:
+          registry: ${{ steps.set-docker-repo.outputs.REGISTRY }}
           # Use existing DockerHub credentials present as secrets
-          username: ${{ secrets.DOCKER_HUB_USER }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+          username: ${{ secrets.DOCKER_HUB_USER || github.actor }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN || secrets.GITHUB_TOKEN }}
 
       ## This step will fail if the docker images is not found
       - name: "Check if image exists"

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -44,8 +44,8 @@ jobs:
       - name: Resolve git 7-chars sha
         id: git-sha7
         run: |
-          echo "SHA7=1.9.8" >> $GITHUB_OUTPUT
-          [ "${{ github.repository }}" == "eclipse-tractusx/knowledge-agents-edc" ] && echo "SHA7=sha-${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+          echo "SHA7=sha-${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+          exit 0
           
   trivy-analyze-config:
     runs-on: ubuntu-latest

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -44,8 +44,9 @@ jobs:
       - name: Resolve git 7-chars sha
         id: git-sha7
         run: |
-          echo "SHA7=sha-${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
-
+          [ "${{ github.repository }}" == "eclipse-tractusx/knowledge-agents-edc" ] && echo "SHA7=sha-${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+          [ "${{ github.repository }}" != "eclipse-tractusx/knowledge-agents-edc" ] && echo "SHA7=1.9.8" >> $GITHUB_OUTPUT
+          
   trivy-analyze-config:
     runs-on: ubuntu-latest
     permissions:
@@ -85,16 +86,17 @@ jobs:
           - agentplane-hashicorp
     steps:
 
+      # Determine the right target docker repo
       - name: Check github repository and set docker repo
         id: set-docker-repo
         run: |
           [ "${{ github.repository }}" == "eclipse-tractusx/knowledge-agents-edc" ] && echo "REPO=tractusx" >> $GITHUB_OUTPUT
-          [ "${{ github.repository }}" == "eclipse-tractusx/knowledge-agents-edc" ] && echo "REPO=ghcr.io/catenax-ng/tx-knowledge-agents-edc" >> $GITHUB_OUTPUT
+          [ "${{ github.repository }}" != "eclipse-tractusx/knowledge-agents-edc" ] && echo "REPO=ghcr.io/${{ github.repository }}" >> $GITHUB_OUTPUT
           exit 0
 
       - uses: actions/checkout@v3.5.2
 
-      # We need to login
+      # Enable repository access (if either running on main or a version tag on eclipse-tractusx)
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         if: ${{ github.repository == 'eclipse-tractusx/knowledge-agents-edc' && ( github.ref == 'refs/heads/main' ||  startsWith(github.ref, 'refs/tags/v')) }}
@@ -110,7 +112,7 @@ jobs:
           docker manifest inspect ${{ steps.set-docker-repo.outputs.REPO }}/${{ matrix.image }}:${{ needs.git-sha7.outputs.value }}
         continue-on-error: true
 
-        ## the next two steps will only execute if the image exists check was successful
+      ## the next two steps will only execute if the image exists check was successful
       - name: Run Trivy vulnerability scanner
         if: success() && steps.imageCheck.outcome != 'failure'
         uses: aquasecurity/trivy-action@master

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -84,11 +84,20 @@ jobs:
           - agentplane-azure-vault
           - agentplane-hashicorp
     steps:
+
+      - name: Check github repository and set docker repo
+        id: set-docker-repo
+        run: |
+          [ "${{ github.repository }}" == "eclipse-tractusx/knowledge-agents-edc" ] && echo "REPO=tractusx" >> $GITHUB_OUTPUT
+          [ "${{ github.repository }}" == "eclipse-tractusx/knowledge-agents-edc" ] && echo "REPO=ghcr.io/catenax-ng/tx-knowledge-agents-edc" >> $GITHUB_OUTPUT
+          exit 0
+
       - uses: actions/checkout@v3.5.2
 
       # We need to login
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
+        if: ${{ github.repository == 'eclipse-tractusx/knowledge-agents-edc' && ( github.ref == 'refs/heads/main' ||  startsWith(github.ref, 'refs/tags/v')) }}
         with:
           # Use existing DockerHub credentials present as secrets
           username: ${{ secrets.DOCKER_HUB_USER }}
@@ -98,7 +107,7 @@ jobs:
       - name: "Check if image exists"
         id: imageCheck
         run: |
-          docker manifest inspect tractusx/${{ matrix.image }}:${{ needs.git-sha7.outputs.value }}
+          docker manifest inspect ${{ steps.set-docker-repo.outputs.REPO }}/${{ matrix.image }}:${{ needs.git-sha7.outputs.value }}
         continue-on-error: true
 
         ## the next two steps will only execute if the image exists check was successful
@@ -106,7 +115,7 @@ jobs:
         if: success() && steps.imageCheck.outcome != 'failure'
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: "tractusx/${{ matrix.image }}:${{ needs.git-sha7.outputs.value }}"
+          image-ref: "${{ steps.set-docker-repo.outputs.REPO }}/${{ matrix.image }}:${{ needs.git-sha7.outputs.value }}"
           format: "sarif"
           output: "trivy-results-${{ matrix.image }}.sarif"
           exit-code: "1"

--- a/agent-plane/agentplane-azure-vault/src/main/docker/Dockerfile
+++ b/agent-plane/agentplane-azure-vault/src/main/docker/Dockerfile
@@ -26,8 +26,6 @@ RUN apk update && apk add curl=8.2.1-r0 --no-cache
 RUN curl -L --proto "=https" -sSf ${OTEL_AGENT_LOCATION} --output /tmp/opentelemetry-javaagent.jar
 
 FROM eclipse-temurin:17-jre-alpine
-ARG JAR
-ARG LIB
 
 ARG APP_USER=docker
 ARG APP_UID=10100
@@ -48,8 +46,8 @@ USER "$APP_USER"
 WORKDIR /app
 
 COPY --from=otel /tmp/opentelemetry-javaagent.jar .
-COPY ${JAR} edc-dataplane.jar
-COPY ${LIB} ./lib/
+COPY target/agentplane-azure-vault.jar edc-dataplane.jar
+COPY target/lib ./lib/
 
 HEALTHCHECK NONE
 

--- a/agent-plane/agentplane-hashicorp/src/main/docker/Dockerfile
+++ b/agent-plane/agentplane-hashicorp/src/main/docker/Dockerfile
@@ -25,8 +25,6 @@ RUN apk update && apk add curl=8.2.1-r0 --no-cache
 RUN curl -L --proto "=https" -sSf ${OTEL_AGENT_LOCATION} --output /tmp/opentelemetry-javaagent.jar
 
 FROM eclipse-temurin:17-jre-alpine
-ARG JAR
-ARG LIB
 
 ARG APP_USER=docker
 ARG APP_UID=10100
@@ -47,8 +45,8 @@ USER "$APP_USER"
 WORKDIR /app
 
 COPY --from=otel /tmp/opentelemetry-javaagent.jar .
-COPY ${JAR} edc-dataplane.jar
-COPY ${LIB} ./lib/
+COPY target/agentplane-hashicorp.jar edc-dataplane.jar
+COPY target/lib ./lib/
 
 HEALTHCHECK NONE
 

--- a/pom.xml
+++ b/pom.xml
@@ -139,10 +139,6 @@
                                     <argument>${platform}</argument>
                                     <argument>-f</argument>
                                     <argument>src/main/docker/Dockerfile</argument>
-                                    <argument>--build-arg</argument>
-                                    <argument>JAR=target/${project.artifactId}.jar</argument>
-                                    <argument>--build-arg</argument>
-                                    <argument>LIB=target/lib</argument>
                                     <argument>-t</argument>
                                     <argument>${repo}${project.artifactId}:${project.version}</argument>
                                     <argument>.</argument>


### PR DESCRIPTION
## WHAT

Backport of solution https://github.com/eclipse-tractusx/knowledge-agents-edc/pull/47 to #46 
Remove all references to catenax-ng in the .github folder

## WHY

see #46 
Catenax-Ng forks are abundant.

## FURTHER NOTES

Closes #46 
