### PR TITLE
fix: Fix parsing postgres & vault urls in helm charts

### DIFF
--- a/charts/agent-connector-azure-vault/Chart.yaml
+++ b/charts/agent-connector-azure-vault/Chart.yaml
@@ -42,7 +42,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.10.3
+version: 1.10.3-SNAPSHOT
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/agent-connector-azure-vault/Chart.yaml
+++ b/charts/agent-connector-azure-vault/Chart.yaml
@@ -42,7 +42,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.10.2-SNAPSHOT
+version: 1.10.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/agent-connector-azure-vault/templates/deployment-dataplane.yaml
+++ b/charts/agent-connector-azure-vault/templates/deployment-dataplane.yaml
@@ -260,7 +260,7 @@ spec:
             - name: "EDC_DATASOURCE_EDR_PASSWORD"
               value: {{ $root.Values.postgresql.auth.password | required ".Values.postgresql.auth.password is required" | quote }}
             - name: "EDC_DATASOURCE_EDR_URL"
-              value: {{ $root.Values.postgresql.jdbcUrl | quote }}
+              value: {{ tpl $root.Values.postgresql.jdbcUrl $root | quote }}
 
             ###########
             ## VAULT ##

--- a/charts/agent-connector-memory/Chart.yaml
+++ b/charts/agent-connector-memory/Chart.yaml
@@ -42,7 +42,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.10.3
+version: 1.10.3-SNAPSHOT
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/agent-connector-memory/Chart.yaml
+++ b/charts/agent-connector-memory/Chart.yaml
@@ -42,7 +42,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.10.2-SNAPSHOT
+version: 1.10.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/agent-connector-memory/templates/deployment-dataplane.yaml
+++ b/charts/agent-connector-memory/templates/deployment-dataplane.yaml
@@ -253,7 +253,7 @@ spec:
 
             # see extension https://github.com/eclipse-tractusx/tractusx-edc/tree/main/edc-extensions/hashicorp-vault
             - name: "EDC_VAULT_HASHICORP_URL"
-              value: {{ $root.Values.vault.hashicorp.url | required ".Values.vault.hashicorp.url is required" | quote }}
+              value: {{ tpl $root.Values.vault.hashicorp.url $root | required ".Values.vault.hashicorp.url is required" | quote }}
             - name: "EDC_VAULT_HASHICORP_TOKEN"
               value: {{ $root.Values.vault.hashicorp.token | required ".Values.vault.hashicorp.token is required" | quote }}
             - name: "EDC_VAULT_HASHICORP_TIMEOUT_SECONDS"

--- a/charts/agent-connector/Chart.yaml
+++ b/charts/agent-connector/Chart.yaml
@@ -41,7 +41,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.10.3
+version: 1.10.3-SNAPSHOT
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/agent-connector/Chart.yaml
+++ b/charts/agent-connector/Chart.yaml
@@ -41,7 +41,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.10.2-SNAPSHOT
+version: 1.10.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/agent-connector/templates/deployment-dataplane.yaml
+++ b/charts/agent-connector/templates/deployment-dataplane.yaml
@@ -259,7 +259,7 @@ spec:
             - name: "EDC_DATASOURCE_EDR_PASSWORD"
               value: {{ $root.Values.postgresql.auth.password | required ".Values.postgresql.auth.password is required" | quote }}
             - name: "EDC_DATASOURCE_EDR_URL"
-              value: {{ $root.Values.postgresql.jdbcUrl | quote }}
+              value: {{ tpl $root.Values.postgresql.jdbcUrl $root | quote }}
 
             ###########
             ## VAULT ##
@@ -267,7 +267,7 @@ spec:
 
             # see extension https://github.com/eclipse-tractusx/tractusx-edc/tree/main/edc-extensions/hashicorp-vault
             - name: "EDC_VAULT_HASHICORP_URL"
-              value: {{ $root.Values.vault.hashicorp.url | required ".Values.vault.hashicorp.url is required" | quote }}
+              value: {{ tpl $root.Values.vault.hashicorp.url $root | required ".Values.vault.hashicorp.url is required" | quote }}
             - name: "EDC_VAULT_HASHICORP_TOKEN"
               value: {{ $root.Values.vault.hashicorp.token | required ".Values.vault.hashicorp.token is required" | quote }}
             - name: "EDC_VAULT_HASHICORP_TIMEOUT_SECONDS"


### PR DESCRIPTION
## WHAT

Pass the PostgreSQL & HashiCorp Vault URLs to the `tpl` function.

## WHY

Else it's not possible to use the default URLs that are specified in the `values.yaml` files.

## FURTHER NOTES

Closes #58 
