### PR TITLE
fix(workflows, docker): Allow to manually trigger build/deployment with deployment options.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,7 +130,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=1.9.8,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+            type=raw,value=1.9.8,enable=${{ github.event.inputs.deploy_docker == 'true' || github.ref == format('refs/heads/{0}', 'main') }}
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 
       - name: Agent Plane Hashicorp Container Build and push
@@ -168,7 +168,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=1.9.8,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+            type=raw,value=1.9.8,enable=${{ github.event.inputs.deploy_docker == 'true' || github.ref == format('refs/heads/{0}', 'main') }}
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 
       - name: Agent Plane Azure Vault Container Build and push

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,6 +95,7 @@ jobs:
 
       # Enable deployment access (on main branch and version tags only)
       - name: Login to GitHub Container Registry
+        if: ${{ ( github.event.inputs.deploy_docker == 'true' || github.ref == 'refs/heads/main' ||  startsWith(github.ref, 'refs/tags/v')) }}
         uses: docker/login-action@v2
         with:
           registry: ${{ steps.set-docker-repo.outputs.REGISTRY }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,8 +74,13 @@ jobs:
       - name: Check github repository and set docker repo
         id: set-docker-repo
         run: |
-          if [ "${{ github.repository }}" == "eclipse-tractusx/knowledge-agents-edc" ]; then echo "REGISTRY=docker.io" >> $GITHUB_OUTPUT; else echo "REGISTRY=ghcr.io" >> $GITHUB_OUTPUT;  fi          
-          if [ "${{ github.repository }}" == "eclipse-tractusx/knowledge-agents-edc" ]; then echo "REPO=tractusx" >> $GITHUB_OUTPUT; else echo "REPO=ghcr.io/${{ github.repository }}" >> $GITHUB_OUTPUT;  fi
+          echo "REGISTRY=ghcr.io" >> $GITHUB_OUTPUT
+          echo "REPO=ghcr.io/${{ github.repository }}" >> $GITHUB_OUTPUT
+          if [ "${{ github.repository }}" == "eclipse-tractusx/knowledge-agents-edc" ]; 
+          then 
+            echo "REGISTRY=docker.io" >> $GITHUB_OUTPUT; 
+            echo "REPO=tractusx" >> $GITHUB_OUTPUT; 
+          fi          
           exit 0
 
       # Get the Code
@@ -145,7 +150,7 @@ jobs:
 
       # Important step to push image description to DockerHub - since this is version independent, we always take it from main
       - name: Update Docker Hub description for Agent Plane Hashicorp
-        if: ${{ github.repository == 'eclipse-tractusx/knowledge-agents-edc'  && github.ref == 'refs/heads/main' }}
+        if: ${{ steps.set-docker-repo.outputs.REPO == 'docker.io'  && github.ref == 'refs/heads/main' }}
         uses: peter-evans/dockerhub-description@v3
         with:
           readme-filepath: agent-plane/agentplane-hashicorp/README.md
@@ -183,7 +188,7 @@ jobs:
 
       # Important step to push image description to DockerHub - since this is version independent, we always take it from main
       - name: Update Docker Hub description for Agent Plane Azure Vault
-        if: ${{ github.repository == 'eclipse-tractusx/knowledge-agents-edc'  && github.ref == 'refs/heads/main' }}
+        if: ${{ steps.set-docker-repo.outputs.REPO == 'docker.io'  && github.ref == 'refs/heads/main' }}
         uses: peter-evans/dockerhub-description@v3
         with:
           readme-filepath: agent-plane/agentplane-azure-vault/README.md

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,4 @@
+---
 #
 #  Copyright (c) 2023 T-Systems International GmbH
 #  Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
@@ -74,13 +75,13 @@ jobs:
       - name: Check github repository and set docker repo
         id: set-docker-repo
         run: |
-          echo "REGISTRY=ghcr.io" >> $GITHUB_OUTPUT
-          echo "REPO=ghcr.io/${{ github.repository }}" >> $GITHUB_OUTPUT
-          if [ "${{ github.repository }}" == "eclipse-tractusx/knowledge-agents-edc" ]; 
-          then 
-            echo "REGISTRY=docker.io" >> $GITHUB_OUTPUT; 
-            echo "REPO=tractusx" >> $GITHUB_OUTPUT; 
-          fi          
+          echo "REGISTRY=docker.io" >> $GITHUB_OUTPUT;
+          echo "REPO=tractusx" >> $GITHUB_OUTPUT;
+          if [ "${{ github.repository }}" != "eclipse-tractusx/knowledge-agents-edc" ];
+          then
+            echo "REGISTRY=ghcr.io" >> $GITHUB_OUTPUT
+            echo "REPO=ghcr.io/${{ github.repository }}" >> $GITHUB_OUTPUT
+          fi
           exit 0
 
       # Get the Code
@@ -94,7 +95,6 @@ jobs:
 
       # Enable deployment access (on main branch and version tags only)
       - name: Login to GitHub Container Registry
-        if: ${{ ( github.event.inputs.deploy_docker == 'true' || github.ref == 'refs/heads/main' ||  startsWith(github.ref, 'refs/tags/v') ) }}
         uses: docker/login-action@v2
         with:
           registry: ${{ steps.set-docker-repo.outputs.REGISTRY }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,17 @@ on:
       - '**/*.md'
   # Manual workflow trigger
   workflow_dispatch:
+    inputs:
+      deploy_maven:
+        description: 'whether maven packages should be deployed (default: false)'
+        default: 'false'
+        required: false
+        type: string
+      deploy_docker:
+        description: 'whether docker images should be deployed (default: true)'
+        default: 'true'
+        required: false
+        type: string
 
 # If build is triggered several times, e.g., through subsequent pushes
 # into the same PR, cancel the previous runs, see below
@@ -78,7 +89,7 @@ jobs:
 
       # Enable deployment access (on main branch and version tags only)
       - name: Login to GitHub Container Registry
-        if: ${{ ( github.ref == 'refs/heads/main' ||  startsWith(github.ref, 'refs/tags/v')) }}
+        if: ${{ ( github.event.inputs.deploy_docker == 'true' || github.ref == 'refs/heads/main' ||  startsWith(github.ref, 'refs/tags/v') ) }}
         uses: docker/login-action@v2
         with:
           registry: ${{ steps.set-docker-repo.outputs.REGISTRY }}
@@ -86,9 +97,9 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USER || github.actor }}
           password: ${{ secrets.DOCKER_HUB_TOKEN || secrets.GITHUB_TOKEN }}
 
-      # Run Maven Deploy (if either running on main or a version tag)
+      # Run Maven Deploy (if either dispatched to do so or running on main or a version tag)
       - name: Deploy Java via Maven
-        if: ${{ ( github.ref == 'refs/heads/main' ||  startsWith(github.ref, 'refs/tags/v')) }}
+        if: ${{ ( github.event.inputs.deploy_maven == 'true' || github.ref == 'refs/heads/main' ||  startsWith(github.ref, 'refs/tags/v') ) }}
         run: |
           ./mvnw -s settings.xml deploy -DaltDeploymentRepository=github::default::https://maven.pkg.github.com/${{ github.repository }}
         env:
@@ -97,7 +108,7 @@ jobs:
 
       # Run Maven Install (otherwise)
       - name: Build Java via Maven
-        if: ${{ ( github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/v')) }}
+        if: ${{ ( github.event.inputs.deploy_maven != 'true' && github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/v')) }}
         run: |
           ./mvnw -s settings.xml install
         env:
@@ -128,7 +139,7 @@ jobs:
           context: agent-plane/agentplane-hashicorp
           file: agent-plane/agentplane-hashicorp/src/main/docker/Dockerfile
           # Build image for verification purposes on every trigger event. Only push if event is not a PR
-          push: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) }}
+          push: ${{ ( github.event.inputs.deploy_docker == 'true' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') ) }}
           tags: ${{ steps.meta-hash.outputs.tags }}
           labels: ${{ steps.meta-hash.outputs.labels }}
 
@@ -166,7 +177,7 @@ jobs:
           context: agent-plane/agentplane-azure-vault/.
           file: agent-plane/agentplane-azure-vault/src/main/docker/Dockerfile
           # Build image for verification purposes on every trigger event. Only push if event is not a PR
-          push: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) }}
+          push: ${{ ( github.event.inputs.deploy_docker == 'true' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') ) }}
           tags: ${{ steps.meta-azr.outputs.tags }}
           labels: ${{ steps.meta-azr.outputs.labels }}
 

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -104,6 +104,7 @@ jobs:
 
       # Enable repository access (on main branch and version tags only)
       - name: Login to GitHub Container Registry
+        if: ${{ ( github.ref == 'refs/heads/main' ||  startsWith(github.ref, 'refs/tags/v')) }}
         uses: docker/login-action@v2
         with:
           registry: ${{ steps.set-docker-repo.outputs.REGISTRY }}

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,3 +1,4 @@
+---
 #
 #  Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 #
@@ -17,7 +18,6 @@
 #  SPDX-License-Identifier: Apache-2.0
 #
 
----
 name: "Trivy"
 
 on:
@@ -25,7 +25,7 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch:
   workflow_run:
-    workflows: [ "Build" ]
+    workflows: ["Build"]
     branches:
       - main
     tags:
@@ -46,7 +46,7 @@ jobs:
         run: |
           echo "SHA7=sha-${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
           exit 0
-          
+
   trivy-analyze-config:
     runs-on: ubuntu-latest
     permissions:
@@ -72,14 +72,15 @@ jobs:
           sarif_file: "trivy-results-config.sarif"
 
   trivy:
-    needs: [ git-sha7 ]
+    needs: [git-sha7]
     permissions:
       actions: read
       contents: read
       security-events: write
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false # continue scanning other images although if the other has been vulnerable
+      # continue scanning other images although if the other has been vulnerable
+      fail-fast: false
       matrix:
         image:
           - agentplane-azure-vault
@@ -90,13 +91,13 @@ jobs:
       - name: Check github repository and set docker repo
         id: set-docker-repo
         run: |
-          echo "REGISTRY=ghcr.io" >> $GITHUB_OUTPUT
-          echo "REPO=ghcr.io/${{ github.repository }}" >> $GITHUB_OUTPUT
-          if [ "${{ github.repository }}" == "eclipse-tractusx/knowledge-agents-edc" ]; 
-          then 
-            echo "REGISTRY=docker.io" >> $GITHUB_OUTPUT; 
-            echo "REPO=tractusx" >> $GITHUB_OUTPUT; 
-          fi          
+          echo "REGISTRY=docker.io" >> $GITHUB_OUTPUT;
+          echo "REPO=tractusx" >> $GITHUB_OUTPUT;
+          if [ "${{ github.repository }}" != "eclipse-tractusx/knowledge-agents-edc" ];
+          then
+            echo "REGISTRY=ghcr.io" >> $GITHUB_OUTPUT
+            echo "REPO=ghcr.io/${{ github.repository }}" >> $GITHUB_OUTPUT
+          fi
           exit 0
 
       - uses: actions/checkout@v3.5.2

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -90,15 +90,19 @@ jobs:
       - name: Check github repository and set docker repo
         id: set-docker-repo
         run: |
-          if [ "${{ github.repository }}" == "eclipse-tractusx/knowledge-agents-edc" ]; then echo "REGISTRY=docker.io" >> $GITHUB_OUTPUT; else echo "REGISTRY=ghcr.io" >> $GITHUB_OUTPUT;  fi          
-          if [ "${{ github.repository }}" == "eclipse-tractusx/knowledge-agents-edc" ]; then echo "REPO=tractusx" >> $GITHUB_OUTPUT; else echo "REPO=ghcr.io/${{ github.repository }}" >> $GITHUB_OUTPUT;  fi
+          echo "REGISTRY=ghcr.io" >> $GITHUB_OUTPUT
+          echo "REPO=ghcr.io/${{ github.repository }}" >> $GITHUB_OUTPUT
+          if [ "${{ github.repository }}" == "eclipse-tractusx/knowledge-agents-edc" ]; 
+          then 
+            echo "REGISTRY=docker.io" >> $GITHUB_OUTPUT; 
+            echo "REPO=tractusx" >> $GITHUB_OUTPUT; 
+          fi          
           exit 0
 
       - uses: actions/checkout@v3.5.2
 
       # Enable repository access (on main branch and version tags only)
       - name: Login to GitHub Container Registry
-        if: ${{ ( github.ref == 'refs/heads/main' ||  startsWith(github.ref, 'refs/tags/v')) }}
         uses: docker/login-action@v2
         with:
           registry: ${{ steps.set-docker-repo.outputs.REGISTRY }}

--- a/agent-plane/agentplane-azure-vault/src/main/docker/Dockerfile
+++ b/agent-plane/agentplane-azure-vault/src/main/docker/Dockerfile
@@ -22,7 +22,7 @@ ENV OTEL_AGENT_LOCATION "https://github.com/open-telemetry/opentelemetry-java-in
 
 HEALTHCHECK NONE
 
-RUN apk update && apk add curl=8.2.1-r0 --no-cache
+RUN apk update && apk add curl=8.3.0-r0 --no-cache
 RUN curl -L --proto "=https" -sSf ${OTEL_AGENT_LOCATION} --output /tmp/opentelemetry-javaagent.jar
 
 FROM eclipse-temurin:17-jre-alpine

--- a/agent-plane/agentplane-hashicorp/src/main/docker/Dockerfile
+++ b/agent-plane/agentplane-hashicorp/src/main/docker/Dockerfile
@@ -21,7 +21,7 @@ ENV OTEL_AGENT_LOCATION "https://github.com/open-telemetry/opentelemetry-java-in
 
 HEALTHCHECK NONE
 
-RUN apk update && apk add curl=8.2.1-r0 --no-cache
+RUN apk update && apk add curl=8.3.0-r0 --no-cache
 RUN curl -L --proto "=https" -sSf ${OTEL_AGENT_LOCATION} --output /tmp/opentelemetry-javaagent.jar
 
 FROM eclipse-temurin:17-jre-alpine


### PR DESCRIPTION
<!--
 * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Apache License, Version 2.0 which is available at
 * https://www.apache.org/licenses/LICENSE-2.0.
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 * License for the specific language governing permissions and limitations
 * under the License.
 *
 * SPDX-License-Identifier: Apache-2.0
-->

## WHAT

The build workflow can now be manually triggered on the release branch with deployment options (towards maven, towards docker).

## WHY

In case that the published packages are fine (no hotfix needed) but the docker images need updates (e.g. if a base image package is obsolete/out-of-date or some meta-data are missing), it should be possible to invoke the build/deployment without having to tamper with version tags.

## FURTHER NOTES

- a docker base image apk was marked out-of-date
- make tractusx/docker.io the default target

Dear "merger": please could you, after the merge when build.yml will once run "without effect", invoke the resulting build.yml workflow on the release/1.9.8 branch (with the effect of the docker images being fixed)?

Closes #46  <-- _insert Issue number if one exists_
