### PR TITLE
fix(docker): upgrade curl version in the alpine build images.

### DIFF
--- a/agent-plane/agentplane-azure-vault/src/main/docker/Dockerfile
+++ b/agent-plane/agentplane-azure-vault/src/main/docker/Dockerfile
@@ -22,7 +22,7 @@ ENV OTEL_AGENT_LOCATION "https://github.com/open-telemetry/opentelemetry-java-in
 
 HEALTHCHECK NONE
 
-RUN apk update && apk add curl=8.3.0-r0 --no-cache
+RUN apk update && apk add curl=8.3.0-r1 --no-cache
 RUN curl -L --proto "=https" -sSf ${OTEL_AGENT_LOCATION} --output /tmp/opentelemetry-javaagent.jar
 
 FROM eclipse-temurin:17-jre-alpine

--- a/agent-plane/agentplane-azure-vault/src/main/docker/Dockerfile
+++ b/agent-plane/agentplane-azure-vault/src/main/docker/Dockerfile
@@ -22,7 +22,7 @@ ENV OTEL_AGENT_LOCATION "https://github.com/open-telemetry/opentelemetry-java-in
 
 HEALTHCHECK NONE
 
-RUN apk update && apk add curl=8.3.0-r1 --no-cache
+RUN apk update && apk add curl=8.4.0-r0 --no-cache
 RUN curl -L --proto "=https" -sSf ${OTEL_AGENT_LOCATION} --output /tmp/opentelemetry-javaagent.jar
 
 FROM eclipse-temurin:17-jre-alpine

--- a/agent-plane/agentplane-hashicorp/src/main/docker/Dockerfile
+++ b/agent-plane/agentplane-hashicorp/src/main/docker/Dockerfile
@@ -21,7 +21,7 @@ ENV OTEL_AGENT_LOCATION "https://github.com/open-telemetry/opentelemetry-java-in
 
 HEALTHCHECK NONE
 
-RUN apk update && apk add curl=8.3.0-r0 --no-cache
+RUN apk update && apk add curl=8.3.0-r1 --no-cache
 RUN curl -L --proto "=https" -sSf ${OTEL_AGENT_LOCATION} --output /tmp/opentelemetry-javaagent.jar
 
 FROM eclipse-temurin:17-jre-alpine

--- a/agent-plane/agentplane-hashicorp/src/main/docker/Dockerfile
+++ b/agent-plane/agentplane-hashicorp/src/main/docker/Dockerfile
@@ -21,7 +21,7 @@ ENV OTEL_AGENT_LOCATION "https://github.com/open-telemetry/opentelemetry-java-in
 
 HEALTHCHECK NONE
 
-RUN apk update && apk add curl=8.3.0-r1 --no-cache
+RUN apk update && apk add curl=8.4.0-r0 --no-cache
 RUN curl -L --proto "=https" -sSf ${OTEL_AGENT_LOCATION} --output /tmp/opentelemetry-javaagent.jar
 
 FROM eclipse-temurin:17-jre-alpine


### PR DESCRIPTION
<!--
 * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Apache License, Version 2.0 which is available at
 * https://www.apache.org/licenses/LICENSE-2.0.
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 * License for the specific language governing permissions and limitations
 * under the License.
 *
 * SPDX-License-Identifier: Apache-2.0
-->

## WHAT

This upgrades the used curl package in the alpine-based build images.

## WHY

build currently does not run (https://github.com/eclipse-tractusx/knowledge-agents-edc/actions/runs/6492062761, https://github.com/eclipse-tractusx/knowledge-agents-edc/actions/runs/6492127770)

## FURTHER NOTES

Many other PRs are failing because of this issue, so it would be good to merge this first.

