### PR TITLE
fix: upgrade to TX-EDC 0.5.3 and resolve trivy/veracode issues.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,4 @@
+---
 #
 #  Copyright (c) 2023 T-Systems International GmbH
 #  Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
@@ -26,6 +27,7 @@ on:
     branches:
       - main
       - 'release/*'
+    # Can be scheduled on all branches and version tags
     tags:
       - 'v*.*.*'
       - 'v*.*.*-*'
@@ -61,7 +63,7 @@ concurrency:
 
 # Actual build/deploy logic
 jobs:
-  # Build maven stuff
+  # Build maven and docker stuff
   build:
     name: Build/Deploy Maven & Docker Artifacts
     runs-on: ubuntu-latest
@@ -74,35 +76,35 @@ jobs:
       - name: Check github repository and set docker repo
         id: set-docker-repo
         run: |
-          echo "REGISTRY=docker.io" >> $GITHUB_OUTPUT; 
-          echo "REPO=tractusx" >> $GITHUB_OUTPUT; 
-          if [ "${{ github.repository }}" != "eclipse-tractusx/knowledge-agents-edc" ]; 
-          then 
+          echo "REGISTRY=docker.io" >> $GITHUB_OUTPUT;
+          echo "REPO=tractusx" >> $GITHUB_OUTPUT;
+          if [ "${{ github.repository }}" != "eclipse-tractusx/knowledge-agents-edc" ];
+          then
             echo "REGISTRY=ghcr.io" >> $GITHUB_OUTPUT
             echo "REPO=ghcr.io/${{ github.repository }}" >> $GITHUB_OUTPUT
-          fi          
+          fi
           exit 0
 
       # Get the Code
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           submodules: recursive
 
       # Setup build environment
       - uses: ./.github/actions/setup-java
 
-      # Enable deployment access (on main branch and version tags only)
+      # Enable deployment access (on demand or main branch and version tags only)
       - name: Login to GitHub Container Registry
-        if: ${{ ( github.event.inputs.deploy_docker == 'true' || github.ref == 'refs/heads/main' ||  startsWith(github.ref, 'refs/tags/v')) }}
-        uses: docker/login-action@v2
+        if: ${{ ( github.event.inputs.deploy_docker == 'true' || github.ref == 'refs/heads/main' ||  startsWith(github.ref, 'refs/tags/v') ) }}
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
         with:
           registry: ${{ steps.set-docker-repo.outputs.REGISTRY }}
           # Use existing DockerHub credentials present as secrets
           username: ${{ secrets.DOCKER_HUB_USER || github.actor }}
           password: ${{ secrets.DOCKER_HUB_TOKEN || secrets.GITHUB_TOKEN }}
 
-      # Run Maven Deploy (if either running on main or a version tag)
+      # Run Maven Deploy (on demand or if either running on main or a version tag)
       - name: Deploy Java via Maven
         if: ${{ ( github.event.inputs.deploy_maven == 'true' || github.ref == 'refs/heads/main' ||  startsWith(github.ref, 'refs/tags/v') ) }}
         run: |
@@ -123,7 +125,7 @@ jobs:
       # Create SemVer or ref tags dependent of trigger event
       - name: Docker Meta Agent Plane Hashicorp
         id: meta-hash
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
         with:
           images: |
             ${{ steps.set-docker-repo.outputs.REPO }}/agentplane-hashicorp
@@ -139,7 +141,7 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 
       - name: Agent Plane Hashicorp Container Build and push
-        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
         with:
           context: agent-plane/agentplane-hashicorp
           file: agent-plane/agentplane-hashicorp/src/main/docker/Dockerfile
@@ -161,7 +163,7 @@ jobs:
       # Create SemVer or ref tags dependent of trigger event
       - name: Docker Meta Agent Plane Azure Vault
         id: meta-azr
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
         with:
           images: |
             ${{ steps.set-docker-repo.outputs.REPO }}/agentplane-azure-vault
@@ -177,7 +179,7 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 
       - name: Agent Plane Azure Vault Container Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
         with:
           context: agent-plane/agentplane-azure-vault/.
           file: agent-plane/agentplane-azure-vault/src/main/docker/Dockerfile
@@ -189,7 +191,7 @@ jobs:
       # Important step to push image description to DockerHub - since this is version independent, we always take it from main
       - name: Update Docker Hub description for Agent Plane Azure Vault
         if: ${{ steps.set-docker-repo.outputs.REPO == 'docker.io' && github.ref == 'refs/heads/main' }}
-        uses: peter-evans/dockerhub-description@v3
+        uses: peter-evans/dockerhub-description@dc67fad7001ef9e8e3c124cb7a64e16d0a63d864 # v3.4.2
         with:
           readme-filepath: agent-plane/agentplane-azure-vault/README.md
           username: ${{ secrets.DOCKER_HUB_USER || github.actor }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,7 +135,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=1.10.6-SNAPSHOT,enable=${{ github.event.inputs.deploy_docker == 'true' || github.ref == format('refs/heads/{0}', 'main') }}
+            type=raw,value=1.10.15-SNAPSHOT,enable=${{ github.event.inputs.deploy_docker == 'true' || github.ref == format('refs/heads/{0}', 'main') }}
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 
       - name: Agent Plane Hashicorp Container Build and push
@@ -173,7 +173,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=1.10.6-SNAPSHOT,enable=${{ github.event.inputs.deploy_docker == 'true' || github.ref == format('refs/heads/{0}', 'main') }}
+            type=raw,value=1.10.15-SNAPSHOT,enable=${{ github.event.inputs.deploy_docker == 'true' || github.ref == format('refs/heads/{0}', 'main') }}
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 
       - name: Agent Plane Azure Vault Container Build and push

--- a/.github/workflows/helm-chart-lint.yml
+++ b/.github/workflows/helm-chart-lint.yml
@@ -42,13 +42,12 @@ on:
     inputs:
       node_image:
         description: 'kindest/node image for k8s kind cluster'
-        # k8s version from 3.1 release as default
-        default: 'kindest/node:v1.24.6'
+        # k8s version from 3.3 release as default
+        default: 'kindest/node:v1.27.3'
         required: false
         type: string
       upgrade_from:
         description: 'chart version to upgrade from'
-        # chart version from 3.2 release as default
         default: 'x.x.x'
         required: false
         type: string

--- a/.github/workflows/helm-chart-lint.yml
+++ b/.github/workflows/helm-chart-lint.yml
@@ -1,3 +1,4 @@
+---
 #
 #  Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
 #
@@ -57,21 +58,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5
         with:
           version: v3.10.3
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
         with:
           python-version: 3.9
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@e6669bcd63d7cb57cb4380c33043eebe5d111992 # v2.4.0
+        uses: helm/chart-testing-action@e6669bcd63d7cb57cb4380c33043eebe5d111992 # v2.6.1
 
       - name: Run chart-testing (list-changed)
         id: list-changed

--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -1,3 +1,4 @@
+---
 #
 #  Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
 #
@@ -40,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
 
@@ -50,11 +51,11 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.5.0
+        uses: helm/chart-releaser-action@a917fd15b20e8b64b94d9158ad54cd6345335584 # v1.6.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/kics.yml
+++ b/.github/workflows/kics.yml
@@ -1,3 +1,4 @@
+---
 #
 #  Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 #
@@ -17,16 +18,15 @@
 #  SPDX-License-Identifier: Apache-2.0
 #
 
----
 name: "KICS"
 
 on:
   push:
-    branches: 
-     - main
-     - 'release/*'
+    branches:
+      - main
+      - 'release/*'
   pull_request:
-    branches: 
+    branches:
       - main
       - 'release/*'
 
@@ -46,26 +46,30 @@ jobs:
       security-events: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-#
-# Take out 
-#   - the "Always" Image Pull Policy Rule (caa3479d-885d-4882-9aac-95e5e78ef5c2) because depending on the deployment/rollout scenarios, other policies are more reasonable.
-#   - the "LimitRange" Namespace Rule (4a20ebac-1060-4c81-95d1-1f7f620e983b) because the target namespace may define that external to the Chart.
-#   - the "ResourceQuota" Namespace Rule (48a5beba-e4c0-4584-a2aa-e6894e4cf424) because the target namespace may define that external to the Chart.
-#
+
+      #
+      # Take out
+      #   - the "Always" Image Pull Policy Rule (caa3479d-885d-4882-9aac-95e5e78ef5c2) because depending on the deployment/rollout scenarios, other policies are more reasonable.
+      #   - the "LimitRange" Namespace Rule (4a20ebac-1060-4c81-95d1-1f7f620e983b) because the target namespace may define that external to the Chart.
+      #   - the "ResourceQuota" Namespace Rule (48a5beba-e4c0-4584-a2aa-e6894e4cf424) because the target namespace may define that external to the Chart.
+      #   - the "Digest" Image Requirement (7c81d34c-8e5a-402b-9798-9f442630e678) can be realised for releases, but not the mainline
+      #   - the "AppArmorProfile" Requirement (8b36775e-183d-4d46-b0f7-96a6f34a723f) is still a beta functionality
+      #   - the "Administrative Boundaries" Info (e84eaf4d-2f45-47b2-abe8-e581b06deb66) would not be visible
+      #
       - name: KICS scan
-        uses: checkmarx/kics-github-action@v1.7.0
+        uses: checkmarx/kics-github-action@8a44970e3d2eca668be41abe9d4e06709c3b3609 # v1.7.0
         with:
           path: "."
           fail_on: high
           disable_secrets: true
-          output_path: kicsResults/          
-          exclude_queries: caa3479d-885d-4882-9aac-95e5e78ef5c2,4a20ebac-1060-4c81-95d1-1f7f620e983b,48a5beba-e4c0-4584-a2aa-e6894e4cf424
+          output_path: kicsResults/
+          exclude_queries: caa3479d-885d-4882-9aac-95e5e78ef5c2,4a20ebac-1060-4c81-95d1-1f7f620e983b,48a5beba-e4c0-4584-a2aa-e6894e4cf424,7c81d34c-8e5a-402b-9798-9f442630e678,8b36775e-183d-4d46-b0f7-96a6f34a723f,e84eaf4d-2f45-47b2-abe8-e581b06deb66
           output_formats: "json,sarif"
 
       - name: Upload SARIF file for GitHub Advanced Security Dashboard
         if: always()
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@689fdc5193eeb735ecb2e52e819e3382876f93f4 # v2.22.6
         with:
           sarif_file: kicsResults/results.sarif

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,3 +1,4 @@
+---
 #
 #  Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 #
@@ -17,7 +18,6 @@
 #  SPDX-License-Identifier: Apache-2.0
 #
 
----
 name: "Trivy"
 
 on:
@@ -25,7 +25,7 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch:
   workflow_run:
-    workflows: [ "Build" ]
+    workflows: ["Build"]
     branches:
       - main
     tags:
@@ -45,8 +45,7 @@ jobs:
         id: git-sha7
         run: |
           echo "SHA7=sha-${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
-          exit 0
-          
+
   trivy-analyze-config:
     runs-on: ubuntu-latest
     permissions:
@@ -54,10 +53,9 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v4
-
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@2b6a709cf9c4025c5438138008beaddbb02086f0 # 0.14.0
+        uses: aquasecurity/trivy-action@2b6a709cf9c4025c5438138008beaddbb02086f0 # v0.14.0
         with:
           scan-type: "config"
           # ignore-unfixed: true
@@ -66,22 +64,22 @@ jobs:
           format: "sarif"
           output: "trivy-results-config.sarif"
           severity: "CRITICAL,HIGH"
-
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@689fdc5193eeb735ecb2e52e819e3382876f93f4 # v2.22.6
         if: always()
         with:
           sarif_file: "trivy-results-config.sarif"
 
   trivy:
-    needs: [ git-sha7 ]
+    needs: [git-sha7]
     permissions:
       actions: read
       contents: read
       security-events: write
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false # continue scanning other images although if the other has been vulnerable
+      # continue scanning other images although if the other has been vulnerable
+      fail-fast: false
       matrix:
         image:
           - agentplane-azure-vault
@@ -92,38 +90,38 @@ jobs:
       - name: Check github repository and set docker repo
         id: set-docker-repo
         run: |
-          echo "REGISTRY=docker.io" >> $GITHUB_OUTPUT; 
-          echo "REPO=tractusx" >> $GITHUB_OUTPUT; 
-          if [ "${{ github.repository }}" != "eclipse-tractusx/knowledge-agents-edc" ]; 
-          then 
+          echo "REGISTRY=docker.io" >> $GITHUB_OUTPUT;
+          echo "REPO=tractusx" >> $GITHUB_OUTPUT;
+          if [ "${{ github.repository }}" != "eclipse-tractusx/knowledge-agents-edc" ];
+          then
             echo "REGISTRY=ghcr.io" >> $GITHUB_OUTPUT
             echo "REPO=ghcr.io/${{ github.repository }}" >> $GITHUB_OUTPUT
-          fi          
+          fi
           exit 0
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       # Enable repository access (on main branch and version tags only)
       - name: Login to GitHub Container Registry
-        if: ${{ ( github.ref == 'refs/heads/main' ||  startsWith(github.ref, 'refs/tags/v')) }}
-        uses: docker/login-action@v2
+        if: ${{ ( github.ref == 'refs/heads/main' ||  startsWith(github.ref, 'refs/tags/v') ) }}
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
         with:
           registry: ${{ steps.set-docker-repo.outputs.REGISTRY }}
           # Use existing DockerHub credentials present as secrets
           username: ${{ secrets.DOCKER_HUB_USER || github.actor }}
           password: ${{ secrets.DOCKER_HUB_TOKEN || secrets.GITHUB_TOKEN }}
 
-      ## This step will fail if the docker images is not found
+      # This step will fail if the docker images is not found
       - name: "Check if image exists"
         id: imageCheck
         run: |
           docker manifest inspect ${{ steps.set-docker-repo.outputs.REPO }}/${{ matrix.image }}:${{ needs.git-sha7.outputs.value }}
         continue-on-error: true
 
-      ## the next two steps will only execute if the image exists check was successful
+      # the next two steps will only execute if the image exists check was successful
       - name: Run Trivy vulnerability scanner
         if: success() && steps.imageCheck.outcome != 'failure'
-        uses: aquasecurity/trivy-action@2b6a709cf9c4025c5438138008beaddbb02086f0 # 0.14.0
+        uses: aquasecurity/trivy-action@2b6a709cf9c4025c5438138008beaddbb02086f0 # v0.14.0
         with:
           image-ref: "${{ steps.set-docker-repo.outputs.REPO }}/${{ matrix.image }}:${{ needs.git-sha7.outputs.value }}"
           format: "sarif"
@@ -131,9 +129,9 @@ jobs:
           exit-code: "1"
           severity: "CRITICAL,HIGH"
           timeout: "10m0s"
-          
+
       - name: Upload Trivy scan results to GitHub Security tab
         if: success() && steps.imageCheck.outcome != 'failure'
-        uses: github/codeql-action/upload-sarif@74483a38d39275f33fcff5f35b679b5ca4a26a99 # v2.22.5
+        uses: github/codeql-action/upload-sarif@689fdc5193eeb735ecb2e52e819e3382876f93f4 # v2.22.6
         with:
           sarif_file: "trivy-results-${{ matrix.image }}.sarif"

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           scan-type: "config"
           # ignore-unfixed: true
-          exit-code: "1"
+          exit-code: "0"
           hide-progress: false
           format: "sarif"
           output: "trivy-results-config.sarif"
@@ -126,7 +126,7 @@ jobs:
           image-ref: "${{ steps.set-docker-repo.outputs.REPO }}/${{ matrix.image }}:${{ needs.git-sha7.outputs.value }}"
           format: "sarif"
           output: "trivy-results-${{ matrix.image }}.sarif"
-          exit-code: "1"
+          exit-code: "0"
           severity: "CRITICAL,HIGH"
           timeout: "10m0s"
 

--- a/.github/workflows/veracode.yml
+++ b/.github/workflows/veracode.yml
@@ -1,3 +1,4 @@
+---
 #
 #  Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 #
@@ -17,7 +18,6 @@
 #  SPDX-License-Identifier: Apache-2.0
 #
 
----
 name: "Veracode"
 
 on:
@@ -42,7 +42,7 @@ jobs:
   verify-formatting:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3.5.2
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup-java
@@ -51,7 +51,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    needs: [ secret-presence, verify-formatting ]
+    needs: [secret-presence, verify-formatting]
     permissions:
       contents: read
     strategy:
@@ -61,7 +61,7 @@ jobs:
                    { dir: agent-plane, name: agentplane-hashicorp } ]
     steps:
       # Set-Up
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: ./.github/actions/setup-java
       # Build
       - name: Build ${{ matrix.variant.name }}
@@ -74,7 +74,7 @@ jobs:
         run: |-
           tar -czvf ${{ matrix.variant.dir }}/${{ matrix.variant.name }}/target/${{ matrix.variant.name }}.tar.gz ${{ matrix.variant.dir }}/${{ matrix.variant.name }}/target/${{ matrix.variant.name }}.jar ${{ matrix.variant.dir }}/${{ matrix.variant.name }}/target/lib/*.jar
       - name: Veracode Upload And Scan
-        uses: veracode/veracode-uploadandscan-action@v1.0
+        uses: veracode/veracode-uploadandscan-action@c3c0b78bddb42d5f6b10d70562f692215a410d7b #v1.0
         if: |
           needs.secret-presence.outputs.ORG_VERACODE_API_ID && needs.secret-presence.outputs.ORG_VERACODE_API_KEY
         continue-on-error: true

--- a/.tractusx
+++ b/.tractusx
@@ -18,5 +18,4 @@
 ###############################################################
 
 product: "Tractus-X Knowledge Agents EDC Extensions (KA-EDC)"
-leadingRepository: "https://github.com/eclipse-tractusx/knowledge-agents-edc"
-repositories: []
+leadingRepository: "https://github.com/eclipse-tractusx/knowledge-agents"

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -54,12 +54,12 @@ maven/mavencentral/io.micrometer/micrometer-registry-prometheus/1.10.5, Apache-2
 maven/mavencentral/io.netty/netty-buffer/4.1.94.Final, Apache-2.0, approved, CQ21842
 maven/mavencentral/io.netty/netty-codec-dns/4.1.93.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.netty/netty-codec-http/4.1.94.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-codec-http2/4.1.100.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-codec-http2/4.1.101.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.netty/netty-codec-socks/4.1.94.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.netty/netty-codec/4.1.94.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.netty/netty-common/4.1.94.Final, Apache-2.0 AND MIT AND CC0-1.0, approved, CQ21843
 maven/mavencentral/io.netty/netty-handler-proxy/4.1.94.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-handler/4.1.94.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-handler/4.1.101.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.netty/netty-resolver-dns-classes-macos/4.1.93.Final, Apache-2.0, approved, #6367
 maven/mavencentral/io.netty/netty-resolver-dns-native-macos/4.1.93.Final, Apache-2.0, approved, #7004
 maven/mavencentral/io.netty/netty-resolver-dns/4.1.93.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
@@ -70,7 +70,7 @@ maven/mavencentral/io.netty/netty-transport-classes-epoll/4.1.94.Final, Apache-2
 maven/mavencentral/io.netty/netty-transport-classes-kqueue/4.1.94.Final, Apache-2.0, approved, #4107
 maven/mavencentral/io.netty/netty-transport-native-epoll/4.1.94.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.netty/netty-transport-native-kqueue/4.1.94.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-transport-native-unix-common/4.1.94.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-transport-native-unix-common/4.1.101.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.netty/netty-transport/4.1.94.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.opentelemetry.instrumentation/opentelemetry-instrumentation-annotations/1.29.0, Apache-2.0, approved, #10087
 maven/mavencentral/io.opentelemetry/opentelemetry-api/1.29.0, Apache-2.0, approved, #10088

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1,7 +1,7 @@
 maven/mavencentral/com.apicatalog/titanium-json-ld/1.3.2, Apache-2.0, approved, #8912
-maven/mavencentral/com.azure/azure-core-http-netty/1.13.4, MIT AND Apache-2.0, approved, #7948
-maven/mavencentral/com.azure/azure-core/1.40.0, MIT, approved, clearlydefined
-maven/mavencentral/com.azure/azure-identity/1.9.1, MIT AND Apache-2.0, approved, #9686
+maven/mavencentral/com.azure/azure-core-http-netty/1.13.6, MIT AND Apache-2.0, approved, #7948
+maven/mavencentral/com.azure/azure-core/1.42.0, MIT AND Apache-2.0, approved, #10089
+maven/mavencentral/com.azure/azure-identity/1.10.0, MIT AND Apache-2.0, approved, #10086
 maven/mavencentral/com.azure/azure-json/1.0.1, MIT AND Apache-2.0, approved, #7933
 maven/mavencentral/com.azure/azure-security-keyvault-secrets/4.6.2, MIT, approved, #7940
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.14.2, Apache-2.0, approved, #5303
@@ -29,7 +29,7 @@ maven/mavencentral/com.github.stephenc.jcip/jcip-annotations/1.0-1, Apache-2.0, 
 maven/mavencentral/com.google.code.gson/gson/2.10.1, Apache-2.0, approved, #6159
 maven/mavencentral/com.google.protobuf/protobuf-java/3.22.2, BSD-3-Clause, approved, #8370
 maven/mavencentral/com.microsoft.azure/msal4j-persistence-extension/1.2.0, MIT, approved, clearlydefined
-maven/mavencentral/com.microsoft.azure/msal4j/1.13.8, MIT, approved, clearlydefined
+maven/mavencentral/com.microsoft.azure/msal4j/1.13.9, MIT, approved, clearlydefined
 maven/mavencentral/com.nimbusds/content-type/2.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.nimbusds/lang-tag/1.7, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.31, Apache-2.0, approved, clearlydefined
@@ -47,38 +47,37 @@ maven/mavencentral/commons-io/commons-io/2.11.0, Apache-2.0, approved, CQ23745
 maven/mavencentral/dev.failsafe/failsafe-okhttp/3.3.2, Apache-2.0, approved, #9178
 maven/mavencentral/dev.failsafe/failsafe/3.3.2, Apache-2.0, approved, #9268
 maven/mavencentral/io.github.classgraph/classgraph/4.8.138, MIT, approved, CQ22530
-maven/mavencentral/io.micrometer/micrometer-commons/1.10.5, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #7333
-maven/mavencentral/io.micrometer/micrometer-core/1.10.5, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #6977
-maven/mavencentral/io.micrometer/micrometer-observation/1.10.5, Apache-2.0, approved, #7331
+maven/mavencentral/io.micrometer/micrometer-commons/1.11.3, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #9243
+maven/mavencentral/io.micrometer/micrometer-core/1.11.3, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #9238
+maven/mavencentral/io.micrometer/micrometer-observation/1.11.3, Apache-2.0, approved, #9242
 maven/mavencentral/io.micrometer/micrometer-registry-prometheus/1.10.5, Apache-2.0, approved, #4721
 maven/mavencentral/io.netty/netty-buffer/4.1.94.Final, Apache-2.0, approved, CQ21842
-maven/mavencentral/io.netty/netty-codec-dns/4.1.91.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-codec-dns/4.1.93.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.netty/netty-codec-http/4.1.94.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-codec-http2/4.1.94.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-codec-socks/4.1.91.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-codec-http2/4.1.100.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-codec-socks/4.1.94.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.netty/netty-codec/4.1.94.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.netty/netty-common/4.1.94.Final, Apache-2.0 AND MIT AND CC0-1.0, approved, CQ21843
-maven/mavencentral/io.netty/netty-handler-proxy/4.1.91.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-handler-proxy/4.1.94.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.netty/netty-handler/4.1.94.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-resolver-dns-classes-macos/4.1.91.Final, Apache-2.0, approved, #6367
-maven/mavencentral/io.netty/netty-resolver-dns-native-macos/4.1.91.Final, Apache-2.0, approved, #7004
-maven/mavencentral/io.netty/netty-resolver-dns/4.1.91.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-resolver-dns-classes-macos/4.1.93.Final, Apache-2.0, approved, #6367
+maven/mavencentral/io.netty/netty-resolver-dns-native-macos/4.1.93.Final, Apache-2.0, approved, #7004
+maven/mavencentral/io.netty/netty-resolver-dns/4.1.93.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.netty/netty-resolver/4.1.94.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-tcnative-boringssl-static/2.0.59.Final, Apache-2.0 OR LicenseRef-Public-Domain OR BSD-2-Clause OR MIT, approved, CQ15280
-maven/mavencentral/io.netty/netty-tcnative-classes/2.0.59.Final, Apache-2.0, approved, clearlydefined
+maven/mavencentral/io.netty/netty-tcnative-boringssl-static/2.0.61.Final, Apache-2.0 OR LicenseRef-Public-Domain OR BSD-2-Clause OR MIT, approved, CQ15280
+maven/mavencentral/io.netty/netty-tcnative-classes/2.0.61.Final, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.netty/netty-transport-classes-epoll/4.1.94.Final, Apache-2.0, approved, #6366
-maven/mavencentral/io.netty/netty-transport-classes-kqueue/4.1.91.Final, Apache-2.0, approved, #4107
-maven/mavencentral/io.netty/netty-transport-native-epoll/4.1.91.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-transport-native-kqueue/4.1.91.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-transport-native-unix-common/4.1.91.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-transport-classes-kqueue/4.1.94.Final, Apache-2.0, approved, #4107
+maven/mavencentral/io.netty/netty-transport-native-epoll/4.1.94.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-transport-native-kqueue/4.1.94.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.netty/netty-transport-native-unix-common/4.1.94.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.netty/netty-transport/4.1.94.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.opentelemetry.instrumentation/opentelemetry-instrumentation-annotations/1.27.0, Apache-2.0, approved, #9270
-maven/mavencentral/io.opentelemetry/opentelemetry-api/1.27.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.opentelemetry/opentelemetry-context/1.27.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.projectreactor.netty/reactor-netty-core/1.0.31, Apache-2.0, approved, #9687
-maven/mavencentral/io.projectreactor.netty/reactor-netty-http/1.0.31, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.projectreactor/reactor-core/3.4.29, Apache-2.0, approved, #7517
+maven/mavencentral/io.opentelemetry.instrumentation/opentelemetry-instrumentation-annotations/1.29.0, Apache-2.0, approved, #10087
+maven/mavencentral/io.opentelemetry/opentelemetry-api/1.29.0, Apache-2.0, approved, #10088
+maven/mavencentral/io.opentelemetry/opentelemetry-context/1.29.0, Apache-2.0, approved, #10090
+maven/mavencentral/io.projectreactor.netty/reactor-netty-core/1.0.33, Apache-2.0, approved, #9687
+maven/mavencentral/io.projectreactor.netty/reactor-netty-http/1.0.33, Apache-2.0, approved, clearlydefined
+maven/mavencentral/io.projectreactor/reactor-core/3.4.30, Apache-2.0, approved, #7517
 maven/mavencentral/io.prometheus/simpleclient/0.16.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.prometheus/simpleclient_common/0.16.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.prometheus/simpleclient_tracer_common/0.16.0, Apache-2.0, approved, clearlydefined
@@ -86,8 +85,8 @@ maven/mavencentral/io.prometheus/simpleclient_tracer_otel/0.16.0, Apache-2.0, ap
 maven/mavencentral/io.prometheus/simpleclient_tracer_otel_agent/0.16.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.swagger.core.v3/swagger-annotations-jakarta/2.2.2, Apache-2.0, approved, #5947
 maven/mavencentral/io.swagger.core.v3/swagger-core-jakarta/2.2.2, Apache-2.0, approved, #5929
-maven/mavencentral/io.swagger.core.v3/swagger-integration-jakarta/2.2.2, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.swagger.core.v3/swagger-jaxrs2-jakarta/2.2.2, Apache-2.0, approved, clearlydefined
+maven/mavencentral/io.swagger.core.v3/swagger-integration-jakarta/2.2.2, Apache-2.0, approved, #11475
+maven/mavencentral/io.swagger.core.v3/swagger-jaxrs2-jakarta/2.2.2, Apache-2.0, approved, #11477
 maven/mavencentral/io.swagger.core.v3/swagger-models-jakarta/2.2.2, Apache-2.0, approved, #5919
 maven/mavencentral/jakarta.activation/jakarta.activation-api/2.1.0, EPL-2.0 OR BSD-3-Clause OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jaf
 maven/mavencentral/jakarta.annotation/jakarta.annotation-api/2.1.1, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.ca
@@ -100,17 +99,16 @@ maven/mavencentral/jakarta.xml.bind/jakarta.xml.bind-api/4.0.0, BSD-3-Clause, ap
 maven/mavencentral/javax.servlet/javax.servlet-api/4.0.1, (CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0) AND Apache-2.0, approved, CQ16125
 maven/mavencentral/junit/junit/4.13.2, EPL-2.0, approved, CQ23636
 maven/mavencentral/net.bytebuddy/byte-buddy-agent/1.14.5, Apache-2.0, approved, #7164
-maven/mavencentral/net.bytebuddy/byte-buddy/1.12.21, Apache-2.0 AND BSD-3-Clause, approved, #1811
 maven/mavencentral/net.bytebuddy/byte-buddy/1.14.5, Apache-2.0 AND BSD-3-Clause, approved, #7163
-maven/mavencentral/net.java.dev.jna/jna-platform/5.6.0, Apache-2.0 OR LGPL-2.1-or-later, approved, CQ22390
+maven/mavencentral/net.java.dev.jna/jna-platform/5.13.0, Apache-2.0 OR LGPL-2.1-or-later, approved, #6707
 maven/mavencentral/net.java.dev.jna/jna/5.12.1, Apache-2.0 OR LGPL-2.1-or-later, approved, #3217
 maven/mavencentral/net.java.dev.jna/jna/5.13.0, Apache-2.0 AND LGPL-2.1-or-later, approved, #6709
-maven/mavencentral/net.minidev/accessors-smart/2.4.9, Apache-2.0, approved, #7515
-maven/mavencentral/net.minidev/json-smart/2.4.10, Apache-2.0, approved, #3288
-maven/mavencentral/org.apache.commons/commons-compress/1.23.0, Apache-2.0 AND BSD-3-Clause, approved, #7506
+maven/mavencentral/net.minidev/accessors-smart/2.4.11, Apache-2.0, approved, #7515
+maven/mavencentral/net.minidev/json-smart/2.4.11, Apache-2.0, approved, #3288
+maven/mavencentral/org.apache.commons/commons-compress/1.24.0, Apache-2.0 AND BSD-3-Clause AND bzip2-1.0.6 AND LicenseRef-Public-Domain, approved, #10368
 maven/mavencentral/org.apache.commons/commons-csv/1.10.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.commons/commons-lang3/3.12.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.apache.commons/commons-pool2/2.11.1, Apache-2.0, approved, CQ23795
+maven/mavencentral/org.apache.commons/commons-pool2/2.12.0, Apache-2.0 AND LicenseRef-Public-Domain, approved, #10843
 maven/mavencentral/org.apache.httpcomponents/httpclient-cache/4.5.14, Apache-2.0, approved, CQ11714
 maven/mavencentral/org.apache.httpcomponents/httpclient/4.5.14, Apache-2.0 AND LicenseRef-Public-Domain, approved, CQ23527
 maven/mavencentral/org.apache.httpcomponents/httpcore/4.4.16, Apache-2.0, approved, CQ23528
@@ -134,66 +132,69 @@ maven/mavencentral/org.apache.jena/jena-tdb2/4.8.0, Apache-2.0, approved, #8881
 maven/mavencentral/org.apache.thrift/libthrift/0.18.1, Apache-2.0, approved, #8911
 maven/mavencentral/org.apiguardian/apiguardian-api/1.1.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.assertj/assertj-core/3.24.2, Apache-2.0, approved, #6161
-maven/mavencentral/org.bouncycastle/bcpkix-jdk18on/1.75, MIT, approved, #9166
-maven/mavencentral/org.bouncycastle/bcprov-jdk18on/1.75, MIT AND CC0-1.0, approved, #9167
-maven/mavencentral/org.bouncycastle/bcutil-jdk18on/1.75, MIT, approved, #9170
+maven/mavencentral/org.bouncycastle/bcpkix-jdk18on/1.76, MIT, approved, #9825
+maven/mavencentral/org.bouncycastle/bcprov-jdk18on/1.76, MIT AND CC0-1.0, approved, #9827
+maven/mavencentral/org.bouncycastle/bcutil-jdk18on/1.76, MIT, approved, #9828
 maven/mavencentral/org.checkerframework/checker-qual/3.31.0, MIT, approved, clearlydefined
 maven/mavencentral/org.codehaus.woodstox/stax2-api/4.2.1, BSD-2-Clause, approved, #2670
-maven/mavencentral/org.eclipse.edc/aggregate-service-spi/0.1.3, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/api-core/0.1.3, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/api-observability/0.1.3, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/auth-spi/0.1.3, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/aws-s3-core/0.1.3, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/boot/0.1.3, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/catalog-spi/0.1.3, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/configuration-filesystem/0.1.3, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/connector-core/0.1.3, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/contract-spi/0.1.3, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/control-api-configuration/0.1.3, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/control-plane-api-client-spi/0.1.3, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/core-spi/0.1.3, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/data-plane-api/0.1.3, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/data-plane-aws-s3/0.1.3, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/data-plane-framework/0.1.3, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/data-plane-http-oauth2-core/0.1.3, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/data-plane-http-oauth2/0.1.3, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/data-plane-http-spi/0.1.3, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/data-plane-http/0.1.3, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/data-plane-spi/0.1.3, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/data-plane-util/0.1.3, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/http-spi/0.1.3, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/http/0.1.3, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/jersey-core/0.1.3, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/jersey-micrometer/0.1.3, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/jersey-providers/0.1.3, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/jetty-core/0.1.3, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/jetty-micrometer/0.1.3, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/json-ld-spi/0.1.3, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/json-ld/0.1.3, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/junit/0.1.3, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/jwt-core/0.1.3, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/jwt-spi/0.1.3, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/micrometer-core/0.1.3, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/oauth2-client/0.1.3, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/oauth2-spi/0.1.3, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/policy-engine-spi/0.1.3, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/policy-engine/0.1.3, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/policy-evaluator/0.1.3, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/policy-model/0.1.3, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/policy-spi/0.1.3, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/runtime-metamodel/0.1.3, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/sql-core/0.1.3, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/sql-pool-apache-commons/0.1.3, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/transaction-datasource-spi/0.1.3, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/transaction-local/0.1.3, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/transaction-spi/0.1.3, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/transfer-spi/0.1.3, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/transform-spi/0.1.3, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/util/0.1.3, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/validator-core/0.1.3, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/validator-spi/0.1.3, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/vault-azure/0.1.3, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/web-spi/0.1.3, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/aggregate-service-spi/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/api-core/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/api-observability/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/auth-spi/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/auth-tokenbased/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/aws-s3-core/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/boot/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/catalog-spi/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/configuration-filesystem/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/connector-core/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/contract-spi/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/control-api-configuration/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/control-plane-api-client-spi/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/core-spi/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/data-plane-api/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/data-plane-aws-s3/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/data-plane-framework/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/data-plane-http-oauth2-core/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/data-plane-http-oauth2/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/data-plane-http-spi/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/data-plane-http/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/data-plane-spi/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/data-plane-util/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/http-spi/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/http/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/jersey-core/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/jersey-micrometer/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/jersey-providers/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/jetty-core/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/jetty-micrometer/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/json-ld-spi/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/json-ld/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/junit/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/jwt-core/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/jwt-spi/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/micrometer-core/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/oauth2-client/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/oauth2-spi/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/policy-engine-spi/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/policy-engine/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/policy-evaluator/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/policy-model/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/policy-spi/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/runtime-metamodel/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/sql-core/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/sql-lease/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/transaction-datasource-spi/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/transaction-local/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/transaction-spi/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/transfer-spi/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/transform-core/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/transform-spi/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/util/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/validator-core/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/validator-spi/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/vault-azure/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/vault-hashicorp/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/web-spi/0.2.1, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.jetty.toolchain/jetty-jakarta-servlet-api/5.0.2, EPL-2.0 OR Apache-2.0, approved, rt.jetty
 maven/mavencentral/org.eclipse.jetty.toolchain/jetty-jakarta-websocket-api/2.0.0, EPL-2.0 OR Apache-2.0, approved, rt.jetty
 maven/mavencentral/org.eclipse.jetty.websocket/websocket-core-client/11.0.15, EPL-2.0 OR Apache-2.0, approved, rt.jetty
@@ -206,49 +207,49 @@ maven/mavencentral/org.eclipse.jetty.websocket/websocket-servlet/11.0.15, EPL-2.
 maven/mavencentral/org.eclipse.jetty/jetty-alpn-client/11.0.15, EPL-2.0 OR Apache-2.0, approved, rt.jetty
 maven/mavencentral/org.eclipse.jetty/jetty-annotations/11.0.15, EPL-2.0 OR Apache-2.0, approved, rt.jetty
 maven/mavencentral/org.eclipse.jetty/jetty-client/11.0.15, EPL-2.0 OR Apache-2.0, approved, rt.jetty
-maven/mavencentral/org.eclipse.jetty/jetty-http/11.0.15, EPL-2.0 OR Apache-2.0, approved, rt.jetty
-maven/mavencentral/org.eclipse.jetty/jetty-io/11.0.15, EPL-2.0 OR Apache-2.0, approved, rt.jetty
+maven/mavencentral/org.eclipse.jetty/jetty-http/11.0.16, EPL-2.0 OR Apache-2.0, approved, rt.jetty
+maven/mavencentral/org.eclipse.jetty/jetty-io/11.0.16, EPL-2.0 OR Apache-2.0, approved, rt.jetty
 maven/mavencentral/org.eclipse.jetty/jetty-jndi/11.0.15, EPL-2.0 OR Apache-2.0, approved, rt.jetty
 maven/mavencentral/org.eclipse.jetty/jetty-plus/11.0.15, EPL-2.0 OR Apache-2.0, approved, rt.jetty
 maven/mavencentral/org.eclipse.jetty/jetty-security/11.0.15, EPL-2.0 OR Apache-2.0, approved, rt.jetty
 maven/mavencentral/org.eclipse.jetty/jetty-server/11.0.15, EPL-2.0 OR Apache-2.0, approved, rt.jetty
 maven/mavencentral/org.eclipse.jetty/jetty-servlet/11.0.15, EPL-2.0 OR Apache-2.0, approved, rt.jetty
-maven/mavencentral/org.eclipse.jetty/jetty-util/11.0.15, EPL-2.0 OR Apache-2.0, approved, rt.jetty
+maven/mavencentral/org.eclipse.jetty/jetty-util/11.0.16, EPL-2.0 OR Apache-2.0, approved, rt.jetty
 maven/mavencentral/org.eclipse.jetty/jetty-webapp/11.0.15, EPL-2.0 OR Apache-2.0, approved, rt.jetty
-maven/mavencentral/org.eclipse.jetty/jetty-xml/11.0.15, EPL-2.0 OR Apache-2.0, approved, rt.jetty
-maven/mavencentral/org.eclipse.tractusx.agents.edc.agent-plane/agent-plane-protocol/1.10.2-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.eclipse.tractusx.edc/auth-jwt/1.10.2-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.eclipse.tractusx.edc/core-spi/0.5.0, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.eclipse.tractusx.edc/edc-dataplane-azure-vault/0.5.0, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.eclipse.tractusx.edc/edc-dataplane-base/0.5.0, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.eclipse.tractusx.edc/edc-dataplane-hashicorp-vault/0.5.0, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.eclipse.tractusx.edc/edc-dataplane-proxy-consumer-api/0.5.0, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.eclipse.tractusx.edc/edc-dataplane-proxy-provider-api/0.5.0, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.eclipse.tractusx.edc/edc-dataplane-proxy-provider-core/0.5.0, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.eclipse.tractusx.edc/edc-dataplane-proxy-provider-spi/0.5.0, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.eclipse.tractusx.edc/edr-cache-core/0.5.0, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.eclipse.tractusx.edc/edr-cache-spi/0.5.0, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.eclipse.tractusx.edc/edr-cache-sql/0.5.0, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.eclipse.tractusx.edc/hashicorp-vault/0.5.0, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.jetty/jetty-xml/11.0.16, EPL-2.0 OR Apache-2.0, approved, rt.jetty
+maven/mavencentral/org.eclipse.tractusx.agents.edc.agent-plane/agent-plane-protocol/1.10.15-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx.edc/auth-jwt/1.10.15-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx.edc/core-spi/0.5.3, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx.edc/edc-dataplane-azure-vault/0.5.3, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx.edc/edc-dataplane-base/0.5.3, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx.edc/edc-dataplane-hashicorp-vault/0.5.3, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx.edc/edc-dataplane-proxy-consumer-api/0.5.3, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx.edc/edc-dataplane-proxy-provider-api/0.5.3, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx.edc/edc-dataplane-proxy-provider-core/0.5.3, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx.edc/edc-dataplane-proxy-provider-spi/0.5.3, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx.edc/edr-cache-core/0.5.3, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx.edc/edr-cache-sql/0.5.3, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx.edc/edr-spi/0.5.3, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx.edc/sql-pool/0.5.3, Apache-2.0, approved, automotive.tractusx
 maven/mavencentral/org.glassfish.hk2.external/aopalliance-repackaged/3.0.4, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish
 maven/mavencentral/org.glassfish.hk2/hk2-api/3.0.4, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish
 maven/mavencentral/org.glassfish.hk2/hk2-locator/3.0.4, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish
 maven/mavencentral/org.glassfish.hk2/hk2-utils/3.0.4, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish
 maven/mavencentral/org.glassfish.hk2/osgi-resource-locator/1.0.3, CDDL-1.0, approved, CQ10889
-maven/mavencentral/org.glassfish.jersey.containers/jersey-container-servlet-core/3.1.2, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
-maven/mavencentral/org.glassfish.jersey.containers/jersey-container-servlet/3.1.2, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
-maven/mavencentral/org.glassfish.jersey.core/jersey-client/3.1.2, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
-maven/mavencentral/org.glassfish.jersey.core/jersey-common/3.1.2, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
-maven/mavencentral/org.glassfish.jersey.core/jersey-server/3.1.2, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
-maven/mavencentral/org.glassfish.jersey.ext/jersey-entity-filtering/3.1.2, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
-maven/mavencentral/org.glassfish.jersey.inject/jersey-hk2/3.1.2, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
-maven/mavencentral/org.glassfish.jersey.media/jersey-media-json-jackson/3.1.2, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
-maven/mavencentral/org.glassfish.jersey.media/jersey-media-multipart/3.1.2, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.containers/jersey-container-servlet-core/3.1.3, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.containers/jersey-container-servlet/3.1.3, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.core/jersey-client/3.1.3, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.core/jersey-common/3.1.3, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.core/jersey-server/3.1.3, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.ext/jersey-entity-filtering/3.1.3, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.inject/jersey-hk2/3.1.3, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.media/jersey-media-json-jackson/3.1.3, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.media/jersey-media-multipart/3.1.3, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
 maven/mavencentral/org.glassfish/jakarta.json/2.0.1, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jsonp
 maven/mavencentral/org.hamcrest/hamcrest-core/1.3, BSD-2-Clause, approved, CQ11429
 maven/mavencentral/org.hdrhistogram/HdrHistogram/2.1.12, BSD-2-Clause OR LicenseRef-Public-Domain, approved, CQ13192
 maven/mavencentral/org.javassist/javassist/3.25.0-GA, MPL-1.1 OR LGPL-2.1-or-later OR Apache-2.0, approved, CQ19885
-maven/mavencentral/org.javassist/javassist/3.29.0-GA, Apache-2.0 AND LGPL-2.1-or-later AND MPL-1.1, approved, #6023
+maven/mavencentral/org.javassist/javassist/3.29.2-GA, Apache-2.0 AND LGPL-2.1-or-later AND MPL-1.1, approved, #6023
 maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib-common/1.6.20, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib-common/1.8.0, Apache-2.0, approved, #8910
 maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib-jdk7/1.6.20, Apache-2.0, approved, clearlydefined
@@ -256,6 +257,7 @@ maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib-jdk7/1.8.0, Apache-2.0, ap
 maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib-jdk8/1.6.20, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib-jdk8/1.8.0, Apache-2.0, approved, #8919
 maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib/1.6.20, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib/1.8.0, Apache-2.0, approved, #8865
 maven/mavencentral/org.jetbrains/annotations/24.0.1, Apache-2.0, approved, #7417
 maven/mavencentral/org.junit-pioneer/junit-pioneer/2.0.1, EPL-2.0, approved, clearlydefined
 maven/mavencentral/org.junit.jupiter/junit-jupiter-api/5.9.3, EPL-2.0, approved, #3133
@@ -271,35 +273,35 @@ maven/mavencentral/org.objenesis/objenesis/3.3, Apache-2.0, approved, clearlydef
 maven/mavencentral/org.opentest4j/opentest4j/1.2.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.ow2.asm/asm-commons/9.5, BSD-3-Clause, approved, #7553
 maven/mavencentral/org.ow2.asm/asm-tree/9.5, BSD-3-Clause, approved, #7555
+maven/mavencentral/org.ow2.asm/asm/9.3, BSD-3-Clause, approved, clearlydefined
 maven/mavencentral/org.ow2.asm/asm/9.5, BSD-3-Clause, approved, #7554
 maven/mavencentral/org.postgresql/postgresql/42.6.0, BSD-2-Clause AND Apache-2.0, approved, #9159
-maven/mavencentral/org.reactivestreams/reactive-streams/1.0.3, CC0-1.0, approved, CQ16332
+maven/mavencentral/org.reactivestreams/reactive-streams/1.0.4, CC0-1.0, approved, CQ16332
 maven/mavencentral/org.rnorth.duct-tape/duct-tape/1.0.8, MIT, approved, clearlydefined
 maven/mavencentral/org.slf4j/slf4j-api/2.0.7, MIT, approved, #5915
 maven/mavencentral/org.testcontainers/junit-jupiter/1.18.3, MIT, approved, #7941
 maven/mavencentral/org.testcontainers/testcontainers/1.18.3, MIT, approved, #7938
-maven/mavencentral/org.testcontainers/vault/1.18.3, MIT, approved, #7927
 maven/mavencentral/org.yaml/snakeyaml/2.0, Apache-2.0 AND (Apache-2.0 OR BSD-3-Clause OR EPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later), approved, #7275
-maven/mavencentral/software.amazon.awssdk/annotations/2.20.94, Apache-2.0, approved, #8598
-maven/mavencentral/software.amazon.awssdk/apache-client/2.20.91, Apache-2.0, approved, #8609
-maven/mavencentral/software.amazon.awssdk/arns/2.20.91, Apache-2.0, approved, #8616
-maven/mavencentral/software.amazon.awssdk/auth/2.20.91, Apache-2.0, approved, #8602
-maven/mavencentral/software.amazon.awssdk/aws-core/2.20.91, Apache-2.0, approved, #8612
-maven/mavencentral/software.amazon.awssdk/aws-query-protocol/2.20.91, Apache-2.0, approved, #8629
-maven/mavencentral/software.amazon.awssdk/aws-xml-protocol/2.20.91, Apache-2.0, approved, #8624
-maven/mavencentral/software.amazon.awssdk/crt-core/2.20.91, Apache-2.0, approved, #8627
-maven/mavencentral/software.amazon.awssdk/endpoints-spi/2.20.91, Apache-2.0, approved, #8604
-maven/mavencentral/software.amazon.awssdk/http-client-spi/2.20.94, Apache-2.0, approved, #8608
-maven/mavencentral/software.amazon.awssdk/iam/2.20.91, Apache-2.0, approved, #9271
-maven/mavencentral/software.amazon.awssdk/json-utils/2.20.91, Apache-2.0, approved, #8614
-maven/mavencentral/software.amazon.awssdk/metrics-spi/2.20.94, Apache-2.0, approved, #8636
-maven/mavencentral/software.amazon.awssdk/netty-nio-client/2.20.94, Apache-2.0, approved, #8613
-maven/mavencentral/software.amazon.awssdk/profiles/2.20.91, Apache-2.0, approved, #8600
-maven/mavencentral/software.amazon.awssdk/protocol-core/2.20.91, Apache-2.0, approved, #8635
-maven/mavencentral/software.amazon.awssdk/regions/2.20.91, Apache-2.0, approved, #8632
-maven/mavencentral/software.amazon.awssdk/s3/2.20.91, Apache-2.0, approved, #8623
-maven/mavencentral/software.amazon.awssdk/sdk-core/2.20.91, Apache-2.0, approved, #8611
-maven/mavencentral/software.amazon.awssdk/sts/2.20.91, Apache-2.0, approved, #9269
-maven/mavencentral/software.amazon.awssdk/third-party-jackson-core/2.20.91, Apache-2.0, approved, #8622
-maven/mavencentral/software.amazon.awssdk/utils/2.20.94, Apache-2.0, approved, #8625
+maven/mavencentral/software.amazon.awssdk/annotations/2.20.162, Apache-2.0, approved, #8598
+maven/mavencentral/software.amazon.awssdk/apache-client/2.20.123, Apache-2.0, approved, #8609
+maven/mavencentral/software.amazon.awssdk/arns/2.20.123, Apache-2.0, approved, #8616
+maven/mavencentral/software.amazon.awssdk/auth/2.20.123, Apache-2.0, approved, #8602
+maven/mavencentral/software.amazon.awssdk/aws-core/2.20.123, Apache-2.0, approved, #8612
+maven/mavencentral/software.amazon.awssdk/aws-query-protocol/2.20.123, Apache-2.0, approved, #8629
+maven/mavencentral/software.amazon.awssdk/aws-xml-protocol/2.20.123, Apache-2.0, approved, #8624
+maven/mavencentral/software.amazon.awssdk/crt-core/2.20.123, Apache-2.0, approved, #8627
+maven/mavencentral/software.amazon.awssdk/endpoints-spi/2.20.123, Apache-2.0, approved, #8604
+maven/mavencentral/software.amazon.awssdk/http-client-spi/2.20.162, Apache-2.0, approved, #8608
+maven/mavencentral/software.amazon.awssdk/iam/2.20.123, Apache-2.0, approved, #9271
+maven/mavencentral/software.amazon.awssdk/json-utils/2.20.123, Apache-2.0, approved, #8614
+maven/mavencentral/software.amazon.awssdk/metrics-spi/2.20.162, Apache-2.0, approved, #8636
+maven/mavencentral/software.amazon.awssdk/netty-nio-client/2.20.162, Apache-2.0, approved, #8613
+maven/mavencentral/software.amazon.awssdk/profiles/2.20.123, Apache-2.0, approved, #8600
+maven/mavencentral/software.amazon.awssdk/protocol-core/2.20.123, Apache-2.0, approved, #8635
+maven/mavencentral/software.amazon.awssdk/regions/2.20.123, Apache-2.0, approved, #8632
+maven/mavencentral/software.amazon.awssdk/s3/2.20.123, Apache-2.0, approved, #8623
+maven/mavencentral/software.amazon.awssdk/sdk-core/2.20.123, Apache-2.0, approved, #8611
+maven/mavencentral/software.amazon.awssdk/sts/2.20.123, Apache-2.0, approved, #9269
+maven/mavencentral/software.amazon.awssdk/third-party-jackson-core/2.20.123, Apache-2.0, approved, #8622
+maven/mavencentral/software.amazon.awssdk/utils/2.20.162, Apache-2.0, approved, #8625
 maven/mavencentral/software.amazon.eventstream/eventstream/1.0.1, Apache-2.0, approved, clearlydefined

--- a/agent-plane/README.md
+++ b/agent-plane/README.md
@@ -66,10 +66,10 @@ mvn package -Pwith-docker-image
 Alternatively, after a successful build, you can invoke docker yourself 
 
 ```console
-docker build -t tractusx/agentplane-azure-vault:1.10.6-SNAPSHOT -f agentplane-azure-vault/src/main/docker/Dockerfile .
+docker build -t tractusx/agentplane-azure-vault:1.10.15-SNAPSHOT -f agentplane-azure-vault/src/main/docker/Dockerfile .
 ```
 
 ```console
-docker build -t tractusx/agentplane-hashicorp:1.10.6-SNAPSHOT -f agentplane-hashicorp/src/main/docker/Dockerfile .
+docker build -t tractusx/agentplane-hashicorp:1.10.15-SNAPSHOT -f agentplane-hashicorp/src/main/docker/Dockerfile .
 ```
 

--- a/agent-plane/agent-plane-protocol/README.md
+++ b/agent-plane/agent-plane-protocol/README.md
@@ -63,7 +63,7 @@ Add the following dependency to your data-plane artifact pom:
         <dependency>
             <groupId>org.eclipse.tractusx.agents.edc</groupId>
             <artifactId>agent-plane-protocol</artifactId>
-            <version>1.10.6-SNAPSHOT</version>
+            <version>1.10.15-SNAPSHOT</version>
         </dependency>
 ```
 

--- a/agent-plane/agent-plane-protocol/pom.xml
+++ b/agent-plane/agent-plane-protocol/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.tractusx.agents.edc</groupId>
         <artifactId>agent-plane</artifactId>
-        <version>1.10.6-SNAPSHOT</version>
+        <version>1.10.15-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -36,7 +36,9 @@
     <packaging>jar</packaging>
 
     <name>Tractus-X Agent-Related Transfer Protocols</name>
-    <description>A Dataplane Extension with SparQL-Over-Http Endpoint, Delegation Capabilities and a Federated Graph-Based Data Catalogue.</description>
+    <description>A Dataplane Extension with SparQL-Over-Http Endpoint, Delegation Capabilities and a Federated
+        Graph-Based Data Catalogue.
+    </description>
     <url>http://catena-x.net/</url>
 
     <properties>
@@ -89,7 +91,7 @@
                     </archive>
                 </configuration>
             </plugin>
-             <plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
@@ -104,7 +106,7 @@
                     </execution>
                 </executions>
             </plugin>
-             <plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
             </plugin>
@@ -219,47 +221,47 @@
 
         <!-- everything for SparQL protocol -->
         <dependency>
-          <groupId>org.apache.jena</groupId>
-          <artifactId>jena-fuseki-core</artifactId>
-          <version>${org.apache.jena.version}</version>
-          <exclusions>
+            <groupId>org.apache.jena</groupId>
+            <artifactId>jena-fuseki-core</artifactId>
+            <version>${org.apache.jena.version}</version>
+            <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-api</artifactId>
-                </exclusion>            
+                </exclusion>
                 <exclusion>
-                  <groupId>org.slf4j</groupId>
-                  <artifactId>jcl-over-slf4j</artifactId>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>jcl-over-slf4j</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.eclipse.jetty</groupId>
                     <artifactId>jetty-server</artifactId>
-                </exclusion>            
+                </exclusion>
                 <exclusion>
                     <groupId>org.eclipse.jetty</groupId>
                     <artifactId>jetty-http</artifactId>
-                </exclusion>            
+                </exclusion>
                 <exclusion>
                     <groupId>org.eclipse.jetty</groupId>
                     <artifactId>jetty-io</artifactId>
-                </exclusion>            
+                </exclusion>
                 <exclusion>
                     <groupId>org.eclipse.jetty</groupId>
                     <artifactId>jetty-security</artifactId>
-                </exclusion>            
+                </exclusion>
                 <exclusion>
                     <groupId>org.eclipse.jetty</groupId>
                     <artifactId>jetty-servlets</artifactId>
-                </exclusion>     
+                </exclusion>
                 <exclusion>
                     <groupId>org.eclipse.jetty</groupId>
                     <artifactId>jetty-servlet</artifactId>
-                </exclusion>            
+                </exclusion>
                 <exclusion>
                     <groupId>org.eclipse.jetty</groupId>
                     <artifactId>jetty-servlet</artifactId>
-                </exclusion>            
-          </exclusions>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- maybe we need advanced storage capacities <dependency>
@@ -300,8 +302,33 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>netty-nio-client</artifactId>
-            <version>2.20.94</version>
+            <version>2.20.162</version>
             <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http2</artifactId>
+            <version>${netty.nio.core-http2.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>${commons.compress.version}</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-http</artifactId>
+            <version>${jetty.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-xml</artifactId>
+            <version>${jetty.version}</version>
         </dependency>
 
         <!-- Compile Only -->
@@ -330,15 +357,15 @@
         </dependency>
         <!-- Test -->
         <dependency>
-         <groupId>org.junit.jupiter</groupId>
-         <artifactId>junit-jupiter-engine</artifactId>
-         <scope>test</scope>
-       </dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
-         <groupId>org.mockito</groupId>
-         <artifactId>mockito-core</artifactId>
-         <scope>test</scope>
-       </dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>jakarta.validation</groupId>
             <artifactId>jakarta.validation-api</artifactId>
@@ -357,6 +384,21 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+            <version>${jetbrains.kotlin.version}</version>
+            <scope>compile</scope>
+        </dependency>
+
+
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
+            <version>${io.micrometer.version}</version>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/agent-plane/agent-plane-protocol/pom.xml
+++ b/agent-plane/agent-plane-protocol/pom.xml
@@ -313,6 +313,12 @@
         </dependency>
 
         <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-handler</artifactId>
+            <version>${netty.nio.core-http2.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
             <version>${commons.compress.version}</version>

--- a/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/http/transfer/AgentSource.java
+++ b/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/http/transfer/AgentSource.java
@@ -85,7 +85,7 @@ public class AgentSource implements DataSource {
         // Agent call, we translate from KA-MATCH to KA-TRANSFER
         String skill=null;
         String graph=null;
-        String asset= request.getSourceDataAddress().getProperties().get(AgentSourceHttpParamsDecorator.ASSET_PROP_ID);
+        String asset = String.valueOf(request.getSourceDataAddress().getProperties().get(AgentSourceHttpParamsDecorator.ASSET_PROP_ID));
         if(asset!=null && asset.length() > 0) {
             Matcher graphMatcher= AgentExtension.GRAPH_PATTERN.matcher(asset);
             if(graphMatcher.matches()) {

--- a/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/http/transfer/AgentSourceHttpParamsDecorator.java
+++ b/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/http/transfer/AgentSourceHttpParamsDecorator.java
@@ -141,13 +141,13 @@ public class AgentSourceHttpParamsDecorator implements HttpParamsDecorator {
         Map<String,List<String>> queryParams=parseParams("?"+getRequestQueryParams(address,request));
 
         if(isTransferRequest(request)) {
-            if(!address.getProperty(BASE_URL).endsWith(SLASH)) {
-                params.baseUrl(address.getProperty(BASE_URL)+SLASH);
+            if(!address.getStringProperty(BASE_URL).endsWith(SLASH)) {
+                params.baseUrl(address.getStringProperty(BASE_URL) + SLASH);
             }
         } else {
             // we need to annotate the base url "pure" because we do not directly hit the endpoint
             params.baseUrl("https://w3id.org/catenax");
-            params.header(DataspaceServiceExecutor.TARGET_URL_SYMBOL.getSymbol(), address.getProperty(BASE_URL));
+            params.header(DataspaceServiceExecutor.TARGET_URL_SYMBOL.getSymbol(), address.getStringProperty(BASE_URL));
 
             // there is the case where a KA-BIND protocol call is
             // one-to-one routed through the transfer plane ... in which case
@@ -165,7 +165,7 @@ public class AgentSourceHttpParamsDecorator implements HttpParamsDecorator {
                 queryParams.remove(QUERY_PARAM);
                 mergeParams(queryParams,bodyParams);
             }
-            String accept=address.getProperty(ACCEPT_HEADER,null);
+            String accept=address.getStringProperty(ACCEPT_HEADER, null);
             List<String> cxAccepts=queryParams.getOrDefault(CX_ACCEPT_PARAM,List.of());
             queryParams.remove(CX_ACCEPT_PARAM);
             if(accept==null) {

--- a/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/sparql/DataspaceServiceExecutor.java
+++ b/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/sparql/DataspaceServiceExecutor.java
@@ -327,7 +327,7 @@ public class DataspaceServiceExecutor implements ServiceExecutor, ChainingServic
                 }
             }
             // the asset type should be annotated in the rdf type property
-            assetType=endpoint.getProperties().getOrDefault("http://www.w3.org/1999/02/22-rdf-syntax-ns#type",assetType);
+            assetType = String.valueOf(endpoint.getProperties().getOrDefault("http://www.w3.org/1999/02/22-rdf-syntax-ns#type", assetType));
 
             // put the endpoint information into a new service operator
             // and cater for the EDC public api slash problem

--- a/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/sparql/SparqlQueryProcessor.java
+++ b/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/sparql/SparqlQueryProcessor.java
@@ -189,7 +189,7 @@ public class SparqlQueryProcessor extends SPARQL_QueryGeneral.SPARQL_QueryProc {
      * @param targetProperties a set of address properties of the asset to invoke
      * @return simulated ok response
      */
-    public Response execute(Request request, String skill, String graph, Map<String,String> targetProperties) {
+    public Response execute(Request request, String skill, String graph, Map<String,Object> targetProperties) {
 
         // wrap jakarta into java.servlet
         HttpServletContextAdapter contextAdapter=new HttpServletContextAdapter(request);
@@ -208,12 +208,14 @@ public class SparqlQueryProcessor extends SPARQL_QueryGeneral.SPARQL_QueryProc {
         action.getContext().set(DataspaceServiceExecutor.AUTH_CODE_SYMBOL,targetProperties.getOrDefault(DataspaceServiceExecutor.AUTH_CODE_SYMBOL.getSymbol(),null));
         action.getContext().set(ARQConstants.sysOptimizerFactory,optimizerFactory);
         if(targetProperties.containsKey(DataspaceServiceExecutor.ALLOW_SYMBOL.getSymbol())) {
-            action.getContext().set(DataspaceServiceExecutor.ALLOW_SYMBOL,Pattern.compile(targetProperties.get(DataspaceServiceExecutor.ALLOW_SYMBOL.getSymbol())));
+            action.getContext().set(DataspaceServiceExecutor.ALLOW_SYMBOL,
+                    Pattern.compile(String.valueOf(targetProperties.get(DataspaceServiceExecutor.ALLOW_SYMBOL.getSymbol()))));
         } else {
             action.getContext().set(DataspaceServiceExecutor.ALLOW_SYMBOL,config.getServiceAssetAllowPattern());
         }
         if(targetProperties.containsKey(DataspaceServiceExecutor.DENY_SYMBOL.getSymbol())) {
-            action.getContext().set(DataspaceServiceExecutor.DENY_SYMBOL,Pattern.compile(targetProperties.get(DataspaceServiceExecutor.DENY_SYMBOL.getSymbol())));
+            action.getContext().set(DataspaceServiceExecutor.DENY_SYMBOL,
+                    Pattern.compile(String.valueOf(targetProperties.get(DataspaceServiceExecutor.DENY_SYMBOL.getSymbol()))));
         } else {
             action.getContext().set(DataspaceServiceExecutor.DENY_SYMBOL,config.getServiceAssetDenyPattern());
         }

--- a/agent-plane/agent-plane-protocol/src/test/java/org/eclipse/tractusx/agents/edc/service/TestDataspaceSynchronizer.java
+++ b/agent-plane/agent-plane-protocol/src/test/java/org/eclipse/tractusx/agents/edc/service/TestDataspaceSynchronizer.java
@@ -88,7 +88,7 @@ public class TestDataspaceSynchronizer {
                 .add("@id", "4bf62562-9026-4dcf-93b5-42ea0de25490")
                 .add("https://w3id.org/edc/v0.0.1/ns/id", "https://w3id.org/catenax/ontology/common#GraphAsset?test:ExampleAsset")
                 .add("https://w3id.org/edc/v0.0.1/ns/contenttype", "application/json, application/xml")
-                .add("https://w3id.org/edc/v0.0.1/ns/version", "1.10.6-SNAPSHOT")
+                .add("https://w3id.org/edc/v0.0.1/ns/version", "1.10.15-SNAPSHOT")
                 .add("https://w3id.org/edc/v0.0.1/ns/name", "Test Asset")
                 .add("https://w3id.org/edc/v0.0.1/ns/description", "Test Asset for RDF Representation")
                 .add("https://w3id.org/catenax/ontology/common#publishedUnderContract", "<https://w3id.org/catenax/ontology/common#Contract?test:Contract>")
@@ -178,7 +178,7 @@ public class TestDataspaceSynchronizer {
                 "                },\n" +
                 "                \"dcat:accessService\": \"ddd4b79e-f785-4e71-9fe5-4a177b3ccf54\"\n" +
                 "            },\n" +
-                "            \"edc:version\": \"1.10.6-SNAPSHOT\",\n" +
+                "            \"edc:version\": \"1.10.15-SNAPSHOT\",\n" +
                 "            \"http://www.w3.org/2000/01/rdf-schema#isDefinedBy\": \"<https://w3id.org/catenax/ontology/diagnosis>\",\n" +
                 "            \"edc:name\": \"Diagnostic Trouble Code Catalogue Version 2022\",\n" +
                 "            \"http://www.w3.org/ns/shacl#shapeGraph\": \"@prefix cx-common: <https://w3id.org/catenax/ontology/common#>. \\n@prefix : <https://w3id.org/catenax/ontology/common#GraphAsset?oem:Diagnosis2022> .\\n@prefix cx-diag: <https://w3id.org/catenax/ontology/diagnosis#> .\\n@prefix owl: <http://www.w3.org/2002/07/owl#> .\\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\\n@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\\n@prefix sh: <http://www.w3.org/ns/shacl#> .\\n\\n:OemDTC rdf:type sh:NodeShape ;\\n  sh:targetClass cx-diag:DTC ;\\n  sh:property [\\n        sh:path cx-diag:provisionedBy ;\\n        sh:hasValue <urn:bpn:legal:BPNL00000003COJN> ;\\n    ] ;\\n  sh:property [\\n        sh:path cx-diag:version ;\\n        sh:hasValue 0^^xsd:long ;\\n    ] ;\\n  sh:property [\\n        sh:path cx-diag:affects ;\\n        sh:class :OemDiagnosedParts ;\\n    ] ;\\n\\n:OemDiagnosedParts rdf:type sh:NodeShape ;\\n  sh:targetClass cx-diag:DiagnosedPart ;\\n  sh:property [\\n        sh:path cx-diag:provisionedBy ;\\n        sh:hasValue <urn:bpn:legal:BPNL00000003COJN> ;\\n    ] ;\\n\",\n" +

--- a/agent-plane/agentplane-azure-vault/README.md
+++ b/agent-plane/agentplane-azure-vault/README.md
@@ -54,7 +54,7 @@ mvn -s ../../../settings.xml install -Pwith-docker-image
 Alternatively, after a sucessful [build](#building) the docker image of the Agent Plane is created using
 
 ```console
-docker build -t tractusx//agentplane-azure-vault:1.10.6-SNAPSHOT -f src/main/docker/Dockerfile .
+docker build -t tractusx//agentplane-azure-vault:1.10.15-SNAPSHOT -f src/main/docker/Dockerfile .
 ```
 
 To run the docker image, you could invoke this command

--- a/agent-plane/agentplane-azure-vault/pom.xml
+++ b/agent-plane/agentplane-azure-vault/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.tractusx.agents.edc</groupId>
         <artifactId>agent-plane</artifactId>
-        <version>1.10.6-SNAPSHOT</version>
+        <version>1.10.15-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -36,7 +36,9 @@
     <packaging>jar</packaging>
 
     <name>Tractus-X Knowledge Agents EDC Dataplane (Az-Vault)</name>
-    <description>Builds a Containerized Agent Dataplane with Agent/Triple Extensions And Accessing the Azure Vault to Store Intermediate Secrets.</description>
+    <description>Builds a Containerized Agent Dataplane with Agent/Triple Extensions And Accessing the Azure Vault to
+        Store Intermediate Secrets.
+    </description>
     <url>http://catena-x.net/</url>
 
     <properties>
@@ -104,7 +106,7 @@
                     </execution>
                 </executions>
             </plugin>
-             <plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
             </plugin>
@@ -123,8 +125,8 @@
                     <artifactId>annotations</artifactId>
                 </exclusion>
                 <exclusion>
-                        <groupId>org.yaml</groupId>
-                        <artifactId>snakeyaml</artifactId>
+                    <groupId>org.yaml</groupId>
+                    <artifactId>snakeyaml</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>dev.failsafe</groupId>
@@ -142,6 +144,18 @@
                     <groupId>com.squareup.okio</groupId>
                     <artifactId>okio</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>net.minidev</groupId>
+                    <artifactId>json-smart</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>net.java.dev.jna</groupId>
+                    <artifactId>jna</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>net.java.dev.jna</groupId>
+                    <artifactId>jna-platform</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -149,6 +163,32 @@
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
             <version>${org.yaml.snakeyaml.version}</version>
+        </dependency>
+
+        <!-- json-smart -->
+        <dependency>
+            <groupId>net.minidev</groupId>
+            <artifactId>json-smart</artifactId>
+            <version>${net.minidev.jsonsmart.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna</artifactId>
+            <version>${net.java.dev.jna.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna-platform</artifactId>
+            <version>${net.java.dev.jna.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.reactivestreams</groupId>
+            <artifactId>reactive-streams</artifactId>
+            <version>${org.reactivestreams.version}</version>
+            <scope>compile</scope>
         </dependency>
 
         <!-- Agent Extensions -->
@@ -166,21 +206,21 @@
 
         <!-- Test -->
         <dependency>
-         <groupId>org.junit.jupiter</groupId>
-         <artifactId>junit-jupiter-engine</artifactId>
-         <scope>test</scope>
-       </dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
-         <groupId>org.mockito</groupId>
-         <artifactId>mockito-core</artifactId>
-         <scope>test</scope>
-         <exclusions>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+            <exclusions>
                 <exclusion>
                     <groupId>net.bytebuddy</groupId>
                     <artifactId>byte-buddy</artifactId>
                 </exclusion>
-         </exclusions>
-       </dependency>
+            </exclusions>
+        </dependency>
 
     </dependencies>
 

--- a/agent-plane/agentplane-azure-vault/src/main/docker/Dockerfile
+++ b/agent-plane/agentplane-azure-vault/src/main/docker/Dockerfile
@@ -31,8 +31,6 @@ ARG APP_USER=docker
 ARG APP_UID=10100
 ARG APP_GID=30000
 
-RUN apk update && apk upgrade libssl3 libcrypto3 --no-cache
-
 RUN addgroup --gid "$APP_GID" --system "$APP_USER"
 
 RUN adduser \

--- a/agent-plane/agentplane-azure-vault/src/main/docker/Dockerfile
+++ b/agent-plane/agentplane-azure-vault/src/main/docker/Dockerfile
@@ -31,6 +31,8 @@ ARG APP_USER=docker
 ARG APP_UID=10100
 ARG APP_GID=30000
 
+RUN apk update && apk upgrade libssl3 libcrypto3 --no-cache
+
 RUN addgroup --gid "$APP_GID" --system "$APP_USER"
 
 RUN adduser \

--- a/agent-plane/agentplane-hashicorp/README.md
+++ b/agent-plane/agentplane-hashicorp/README.md
@@ -54,7 +54,7 @@ mvn -s ../../../settings.xml install -Pwith-docker-image
 Alternatively, after a sucessful [build](#building) the docker image of the Agent Plane is created using
 
 ```console
-docker build -t tractusx/agentplane-hashicorp:1.10.6-SNAPSHOT -f src/main/docker/Dockerfile .
+docker build -t tractusx/agentplane-hashicorp:1.10.15-SNAPSHOT -f src/main/docker/Dockerfile .
 ```
 
 To run the docker image, you could invoke this command
@@ -66,7 +66,7 @@ docker run -p 8082:8082 \
   -v $(pwd)/resources/dataplane.properties:/app/configuration.properties \
   -v $(pwd)/resources/opentelemetry.properties:/app/opentelemetry.properties \
   -v $(pwd)/resources/logging.properties:/app/logging.properties \
-  tractusx/agentplane-hashicorp:1.10.6-SNAPSHOT
+  tractusx/agentplane-hashicorp:1.10.15-SNAPSHOT
 ````
 
 Afterwards, you should be able to access the [local SparQL endpoint](http://localhost:8082/api/agent) via

--- a/agent-plane/agentplane-hashicorp/pom.xml
+++ b/agent-plane/agentplane-hashicorp/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.tractusx.agents.edc</groupId>
         <artifactId>agent-plane</artifactId>
-        <version>1.10.6-SNAPSHOT</version>
+        <version>1.10.15-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/agent-plane/agentplane-hashicorp/src/main/docker/Dockerfile
+++ b/agent-plane/agentplane-hashicorp/src/main/docker/Dockerfile
@@ -30,8 +30,6 @@ ARG APP_USER=docker
 ARG APP_UID=10100
 ARG APP_GID=30000
 
-RUN apk update && apk upgrade libssl3 libcrypto3 --no-cache
-
 RUN addgroup --gid "$APP_GID" --system "$APP_USER"
 
 RUN adduser \

--- a/agent-plane/agentplane-hashicorp/src/main/docker/Dockerfile
+++ b/agent-plane/agentplane-hashicorp/src/main/docker/Dockerfile
@@ -30,6 +30,8 @@ ARG APP_USER=docker
 ARG APP_UID=10100
 ARG APP_GID=30000
 
+RUN apk update && apk upgrade libssl3 libcrypto3 --no-cache
+
 RUN addgroup --gid "$APP_GID" --system "$APP_USER"
 
 RUN adduser \

--- a/agent-plane/pom.xml
+++ b/agent-plane/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.eclipse.tractusx.agents</groupId>
         <artifactId>edc</artifactId>
-        <version>1.10.6-SNAPSHOT</version>
+        <version>1.10.15-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>    
     </parent>
     <name>Tractus-X EDC Agent Plane</name>

--- a/charts/agent-connector-azure-vault/Chart.yaml
+++ b/charts/agent-connector-azure-vault/Chart.yaml
@@ -42,12 +42,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.10.6-SNAPSHOT
+version: 1.10.15-SNAPSHOT
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.10.6-SNAPSHOT"
+appVersion: "1.10.15-SNAPSHOT"
 home: https://github.com/eclipse-tractusx/knowledge-agents-edc/
 sources:
   - https://github.com/eclipse-tractusx/knowledge-agents-edc/tree/main/charts/agent-connector

--- a/charts/agent-connector-azure-vault/README.md
+++ b/charts/agent-connector-azure-vault/README.md
@@ -20,7 +20,7 @@
 
 # agent-connector-azure-vault
 
-![Version: 1.10.6-SNAPSHOT](https://img.shields.io/badge/Version-1.9.8--SNAPSHOT-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.10.6-SNAPSHOT](https://img.shields.io/badge/AppVersion-1.9.5--SNAPSHOT-informational?style=flat-square)
+![Version: 1.10.15-SNAPSHOT](https://img.shields.io/badge/Version-1.9.8--SNAPSHOT-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.10.15-SNAPSHOT](https://img.shields.io/badge/AppVersion-1.9.5--SNAPSHOT-informational?style=flat-square)
 
 A Helm chart for an Agent-Enabled Tractus-X Eclipse Data Space Connector configured against Azure Vault. This is a variant of [the Tractus-X Azure Vault Connector Helm Chart](https://github.com/eclipse-tractusx/tractusx-edc/tree/main/charts/tractusx-connector-azure-vault) which allows
 to deal with several data (and agent) planes. The connector deployment consists of at least two runtime consists of a
@@ -112,7 +112,7 @@ Combined, run this shell command to start the in-memory Tractus-X EDC runtime:
 
 ```shell
 helm repo add eclipse-tractusx https://eclipse-tractusx.github.io/charts/dev
-helm install my-release eclipse-tractusx/agent-connector-azure-vault --version 1.10.6-SNAPSHOT\
+helm install my-release eclipse-tractusx/agent-connector-azure-vault --version 1.10.15-SNAPSHOT\
      -f <path-to>/tractusx-connector-azure-vault-test.yaml \
      --set vault.azure.name=$AZURE_VAULT_NAME \
      --set vault.azure.client=$AZURE_CLIENT_ID \

--- a/charts/agent-connector-memory/Chart.yaml
+++ b/charts/agent-connector-memory/Chart.yaml
@@ -42,12 +42,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.10.6-SNAPSHOT
+version: 1.10.15-SNAPSHOT
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.10.6-SNAPSHOT"
+appVersion: "1.10.15-SNAPSHOT"
 home: https://github.com/eclipse-tractusx/knowledge-agents-edc/
 sources:
   - https://github.com/eclipse-tractusx/knowledge-agents-edc/tree/main/charts/agent-connector

--- a/charts/agent-connector-memory/README.md
+++ b/charts/agent-connector-memory/README.md
@@ -20,7 +20,7 @@
 
 # agent-connector-memory
 
-![Version: 1.10.6-SNAPSHOT](https://img.shields.io/badge/Version-1.9.8--SNAPSHOT-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.10.6-SNAPSHOT](https://img.shields.io/badge/AppVersion-1.9.5--SNAPSHOT-informational?style=flat-square)
+![Version: 1.10.15-SNAPSHOT](https://img.shields.io/badge/Version-1.9.8--SNAPSHOT-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.10.15-SNAPSHOT](https://img.shields.io/badge/AppVersion-1.9.5--SNAPSHOT-informational?style=flat-square)
 
 A Helm chart for an Agent-Enabled Tractus-X Eclipse Data Space Connector using In-Memory Persistence. This is a variant of [the Tractus-X In-Memory Connector Helm Chart](https://github.com/eclipse-tractusx/tractusx-edc/tree/main/charts/tractusx-connector-memory) which allows
 to deal with several data (and agent) planes. The connector deployment consists of at least two runtime consists of a
@@ -108,7 +108,7 @@ Combined, run this shell command to start the in-memory Tractus-X EDC runtime:
 
 ```shell
 helm repo add eclipse-tractusx https://eclipse-tractusx.github.io/charts/dev
-helm install my-release eclipse-tractusx/agent-connector --version 1.10.6-SNAPSHOT
+helm install my-release eclipse-tractusx/agent-connector --version 1.10.15-SNAPSHOT
 ```
 
 ## Maintainers

--- a/charts/agent-connector/Chart.yaml
+++ b/charts/agent-connector/Chart.yaml
@@ -41,12 +41,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.10.6-SNAPSHOT
+version: 1.10.15-SNAPSHOT
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.10.6-SNAPSHOT"
+appVersion: "1.10.15-SNAPSHOT"
 home: https://github.com/eclipse-tractusx/knowledge-agents-edc/
 sources:
   - https://github.com/eclipse-tractusx/knowledge-agents-edc/tree/main/charts/agent-connector

--- a/charts/agent-connector/README.md
+++ b/charts/agent-connector/README.md
@@ -20,7 +20,7 @@
 
 # agent-connector
 
-![Version: 1.10.6-SNAPSHOT](https://img.shields.io/badge/Version-1.9.8--SNAPSHOT-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.10.6-SNAPSHOT](https://img.shields.io/badge/AppVersion-1.9.5--SNAPSHOT-informational?style=flat-square)
+![Version: 1.10.15-SNAPSHOT](https://img.shields.io/badge/Version-1.9.8--SNAPSHOT-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.10.15-SNAPSHOT](https://img.shields.io/badge/AppVersion-1.9.5--SNAPSHOT-informational?style=flat-square)
 
 A Helm chart for an Agent-Enabled Tractus-X Eclipse Data Space Connector. This is a variant of [the Tractus-X Connector Helm Chart](https://github.com/eclipse-tractusx/tractusx-edc/tree/main/charts/tractusx-connector) which allows
 to deal with several data (and agent) planes. The connector deployment consists of at least two runtime consists of a
@@ -108,7 +108,7 @@ Combined, run this shell command to start the in-memory Tractus-X EDC runtime:
 
 ```shell
 helm repo add eclipse-tractusx https://eclipse-tractusx.github.io/charts/dev
-helm install my-release eclipse-tractusx/agent-connector --version 1.10.6-SNAPSHOT
+helm install my-release eclipse-tractusx/agent-connector --version 1.10.15-SNAPSHOT
 ```
 
 ## Maintainers

--- a/common/README.md
+++ b/common/README.md
@@ -57,7 +57,7 @@ add the following dependency to your maven dependencies (gradle should work anal
         <dependency>
           <groupId>org.eclipse.tractusx.edc</groupId>
           <artifactId>auth-jwt</artifactId>
-          <version>1.10.6-SNAPSHOT</version>
+          <version>1.10.15-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/common/auth-jwt/README.md
+++ b/common/auth-jwt/README.md
@@ -37,7 +37,7 @@ Add the following dependency to your EDC artifact pom:
         <dependency>
             <groupId>org.eclipse.tractusx.agents.edc</groupId>
             <artifactId>auth-jwt</artifactId>
-            <version>1.10.6-SNAPSHOT</version>
+            <version>1.10.15-SNAPSHOT</version>
         </dependency>
 ```
 

--- a/common/auth-jwt/pom.xml
+++ b/common/auth-jwt/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.eclipse.tractusx.agents</groupId>
         <artifactId>edc</artifactId>
-        <version>1.10.6-SNAPSHOT</version>
+        <version>1.10.15-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -76,7 +76,7 @@ dependencies:
   
     - name: agent-connector-memory
       repository: https://eclipse-tractusx.github.io/charts/dev
-      version: 1.10.6-SNAPSHOT
+      version: 1.10.15-SNAPSHOT
       alias: my-connector
 ```
 
@@ -87,7 +87,7 @@ dependencies:
   
     - name: agent-connector-azure-vault
       repository: https://eclipse-tractusx.github.io/charts/dev
-      version: 1.10.6-SNAPSHOT
+      version: 1.10.15-SNAPSHOT
       alias: my-connector
 ```
 
@@ -98,7 +98,7 @@ dependencies:
   
     - name: agent-connector
       repository: https://eclipse-tractusx.github.io/charts/dev
-      version: 1.10.6-SNAPSHOT
+      version: 1.10.15-SNAPSHOT
       alias: my-connector
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <org.reactivestreams.version>1.0.4</org.reactivestreams.version>
         <jetbrains.kotlin.version>1.8.0</jetbrains.kotlin.version>
         <io.micrometer.version>1.11.3</io.micrometer.version>
-        <netty.nio.core-http2.version>4.1.100.Final</netty.nio.core-http2.version>
+        <netty.nio.core-http2.version>4.1.101.Final</netty.nio.core-http2.version>
         <commons.compress.version>1.24.0</commons.compress.version>
         <jetty.version>11.0.16</jetty.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.eclipse.tractusx.agents</groupId>
     <artifactId>edc</artifactId>
-    <version>1.10.6-SNAPSHOT</version>
+    <version>1.10.15-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Tractus-X Knowledge Agents EDC Extensions</name>
     <description>EDC-Related Artifacts for Federated Procedure Calls</description>
@@ -39,8 +39,8 @@
 
         <junit.version>5.9.3</junit.version>
         <mockito.version>5.4.0</mockito.version>
-        <tx.edc.version>0.5.0</tx.edc.version>
-        <edc.version>0.1.3</edc.version>
+        <tx.edc.version>0.5.3</tx.edc.version>
+        <edc.version>0.2.1</edc.version>
         <failsafe.version>3.3.2</failsafe.version>
         <okhttp.version>4.11.0</okhttp.version>
         <okio.version>3.4.0</okio.version>
@@ -51,10 +51,17 @@
         <javax.servlet-api.version>4.0.1</javax.servlet-api.version>
         <jetty-jakarta-servlet-api.version>5.0.2</jetty-jakarta-servlet-api.version>
         <org.apache.jena.version>4.8.0</org.apache.jena.version>
-        <com.azure.azure-identity.version>1.9.1</com.azure.azure-identity.version>
+        <com.azure.azure-identity.version>1.10.0</com.azure.azure-identity.version>
         <com.azure.azure-security-keyvault-secrets.version>4.6.2</com.azure.azure-security-keyvault-secrets.version>
         <org.yaml.snakeyaml.version>2.0</org.yaml.snakeyaml.version>
         <net.minidev.jsonsmart.version>2.4.11</net.minidev.jsonsmart.version>
+        <net.java.dev.jna.version>5.13.0</net.java.dev.jna.version>
+        <org.reactivestreams.version>1.0.4</org.reactivestreams.version>
+        <jetbrains.kotlin.version>1.8.0</jetbrains.kotlin.version>
+        <io.micrometer.version>1.11.3</io.micrometer.version>
+        <netty.nio.core-http2.version>4.1.100.Final</netty.nio.core-http2.version>
+        <commons.compress.version>1.24.0</commons.compress.version>
+        <jetty.version>11.0.16</jetty.version>
 
         <!-- Source characteristics -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/upgrade_version.sh
+++ b/upgrade_version.sh
@@ -16,7 +16,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-echo Upgrading from 10.1.6-SNAPSHOT to $1
-PATTERN=s/10.1.6-SNAPSHOT/$1/g
+OLD_VERSION=1.10.15-SNAPSHOT
+echo Upgrading from $OLD_VERSION to $1
+PATTERN=s/$OLD_VERSION/$1/g
 LC_ALL=C
 find ./ -type f \( -iname "*.xml" -o -iname "*.sh"  -o -iname "*.yml"  -o -iname "*.yaml"  -o -iname "*.md"  -o -iname "*.java" -o -iname "*.properties" \) -exec sed -i.bak $PATTERN {} \;


### PR DESCRIPTION
<!--
 * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Apache License, Version 2.0 which is available at
 * https://www.apache.org/licenses/LICENSE-2.0.
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 * License for the specific language governing permissions and limitations
 * under the License.
 *
 * SPDX-License-Identifier: Apache-2.0
-->

## WHAT

This PR upgrades the KA agent planes to depend on TX-EDC 0.5.3 (upcoming CX 23.12) and EDC 0.2.1
It furthermore resolves all open veracode issues that have accumulated until today.
Instead of fixing the base image, we allow trivy findings of CRITITCAL and HIGH vulnerability to proceed the action.
Finally it updates the version of this product and its modules and charts and integrates it with the other repos into a single Tractus-X product.

## WHY

trivy and veracode issues have accumulated.
In order to resolve them, we first upgrade the main (nested) dependencies and then look for appropriate patches to the still vulnerable artifacts (jars).
Finally we upgrade the version in order to prepare the next release (23.12) such that all Agent-Related repos appear under a leading umbrella.

## FURTHER NOTES

(Jar) Dependencies have been update and checked.
The base image vulnerabilities are not touched because of legal puposes.

