### PR TITLE
chore: remove SNAPSHOT version to prepare release.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,7 +137,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=1.11.16-SNAPSHOT,enable=${{ github.event.inputs.deploy_docker == 'true' || github.ref == format('refs/heads/{0}', 'main') }}
+            type=raw,value=1.11.16,enable=${{ github.event.inputs.deploy_docker == 'true' || github.ref == format('refs/heads/{0}', 'main') }}
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 
       - name: Agent Plane Hashicorp Container Build and push
@@ -175,7 +175,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=1.11.16-SNAPSHOT,enable=${{ github.event.inputs.deploy_docker == 'true' || github.ref == format('refs/heads/{0}', 'main') }}
+            type=raw,value=1.11.16,enable=${{ github.event.inputs.deploy_docker == 'true' || github.ref == format('refs/heads/{0}', 'main') }}
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 
       - name: Agent Plane Azure Vault Container Build and push

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,16 @@ All notable changes to this product will be documented in this file.
 
 # Released
 
+## [1.11.16] - 2024-02-20
+
+### Added
+
+### Changed
+
+- Bug fixes related to Federated Catalogue and Skill Provisioning
+
+### Removed
+
 ## [1.10.15] - 2023-11-22
 
 ### Added

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -224,8 +224,8 @@ maven/mavencentral/org.eclipse.jetty/jetty-servlet/11.0.15, EPL-2.0 OR Apache-2.
 maven/mavencentral/org.eclipse.jetty/jetty-util/11.0.16, EPL-2.0 OR Apache-2.0, approved, rt.jetty
 maven/mavencentral/org.eclipse.jetty/jetty-webapp/11.0.15, EPL-2.0 OR Apache-2.0, approved, rt.jetty
 maven/mavencentral/org.eclipse.jetty/jetty-xml/11.0.16, EPL-2.0 OR Apache-2.0, approved, rt.jetty
-maven/mavencentral/org.eclipse.tractusx.agents.edc.agent-plane/agent-plane-protocol/1.11.16-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.eclipse.tractusx.edc/auth-jwt/1.11.16-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx.agents.edc.agent-plane/agent-plane-protocol/1.11.16, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx.edc/auth-jwt/1.11.16, Apache-2.0, approved, automotive.tractusx
 maven/mavencentral/org.eclipse.tractusx.edc/core-spi/0.5.3, Apache-2.0, approved, automotive.tractusx
 maven/mavencentral/org.eclipse.tractusx.edc/edc-dataplane-azure-vault/0.5.3, Apache-2.0, approved, automotive.tractusx
 maven/mavencentral/org.eclipse.tractusx.edc/edc-dataplane-base/0.5.3, Apache-2.0, approved, automotive.tractusx

--- a/agent-plane/README.md
+++ b/agent-plane/README.md
@@ -66,10 +66,10 @@ mvn package -Pwith-docker-image
 Alternatively, after a successful build, you can invoke docker yourself 
 
 ```console
-docker build -t tractusx/agentplane-azure-vault:1.11.16-SNAPSHOT -f agentplane-azure-vault/src/main/docker/Dockerfile .
+docker build -t tractusx/agentplane-azure-vault:1.11.16 -f agentplane-azure-vault/src/main/docker/Dockerfile .
 ```
 
 ```console
-docker build -t tractusx/agentplane-hashicorp:1.11.16-SNAPSHOT -f agentplane-hashicorp/src/main/docker/Dockerfile .
+docker build -t tractusx/agentplane-hashicorp:1.11.16 -f agentplane-hashicorp/src/main/docker/Dockerfile .
 ```
 

--- a/agent-plane/agent-plane-protocol/README.md
+++ b/agent-plane/agent-plane-protocol/README.md
@@ -63,7 +63,7 @@ Add the following dependency to your data-plane artifact pom:
         <dependency>
             <groupId>org.eclipse.tractusx.agents.edc</groupId>
             <artifactId>agent-plane-protocol</artifactId>
-            <version>1.11.16-SNAPSHOT</version>
+            <version>1.11.16</version>
         </dependency>
 ```
 

--- a/agent-plane/agent-plane-protocol/pom.xml
+++ b/agent-plane/agent-plane-protocol/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.tractusx.agents.edc</groupId>
         <artifactId>agent-plane</artifactId>
-        <version>1.11.16-SNAPSHOT</version>
+        <version>1.11.16</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/agent-plane/agent-plane-protocol/src/test/java/org/eclipse/tractusx/agents/edc/service/TestDataspaceSynchronizer.java
+++ b/agent-plane/agent-plane-protocol/src/test/java/org/eclipse/tractusx/agents/edc/service/TestDataspaceSynchronizer.java
@@ -88,7 +88,7 @@ public class TestDataspaceSynchronizer {
                 .add("@id", "4bf62562-9026-4dcf-93b5-42ea0de25490")
                 .add("https://w3id.org/edc/v0.0.1/ns/id", "https://w3id.org/catenax/ontology/common#GraphAsset?test:ExampleAsset")
                 .add("https://w3id.org/edc/v0.0.1/ns/contenttype", "application/json, application/xml")
-                .add("https://w3id.org/edc/v0.0.1/ns/version", "1.11.16-SNAPSHOT")
+                .add("https://w3id.org/edc/v0.0.1/ns/version", "1.11.16")
                 .add("https://w3id.org/edc/v0.0.1/ns/name", "Test Asset")
                 .add("https://w3id.org/edc/v0.0.1/ns/description", "Test Asset for RDF Representation")
                 .add("https://w3id.org/catenax/ontology/common#publishedUnderContract", "<https://w3id.org/catenax/ontology/common#Contract?test:Contract>")
@@ -178,7 +178,7 @@ public class TestDataspaceSynchronizer {
                 "                },\n" +
                 "                \"dcat:accessService\": \"ddd4b79e-f785-4e71-9fe5-4a177b3ccf54\"\n" +
                 "            },\n" +
-                "            \"edc:version\": \"1.11.16-SNAPSHOT\",\n" +
+                "            \"edc:version\": \"1.11.16\",\n" +
                 "            \"http://www.w3.org/2000/01/rdf-schema#isDefinedBy\": \"<https://w3id.org/catenax/ontology/diagnosis>\",\n" +
                 "            \"edc:name\": \"Diagnostic Trouble Code Catalogue Version 2022\",\n" +
                 "            \"http://www.w3.org/ns/shacl#shapeGraph\": \"@prefix cx-common: <https://w3id.org/catenax/ontology/common#>. \\n@prefix : <https://w3id.org/catenax/ontology/common#GraphAsset?oem:Diagnosis2022> .\\n@prefix cx-diag: <https://w3id.org/catenax/ontology/diagnosis#> .\\n@prefix owl: <http://www.w3.org/2002/07/owl#> .\\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\\n@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\\n@prefix sh: <http://www.w3.org/ns/shacl#> .\\n\\n:OemDTC rdf:type sh:NodeShape ;\\n  sh:targetClass cx-diag:DTC ;\\n  sh:property [\\n        sh:path cx-diag:provisionedBy ;\\n        sh:hasValue <urn:bpn:legal:BPNL00000003COJN> ;\\n    ] ;\\n  sh:property [\\n        sh:path cx-diag:version ;\\n        sh:hasValue 0^^xsd:long ;\\n    ] ;\\n  sh:property [\\n        sh:path cx-diag:affects ;\\n        sh:class :OemDiagnosedParts ;\\n    ] ;\\n\\n:OemDiagnosedParts rdf:type sh:NodeShape ;\\n  sh:targetClass cx-diag:DiagnosedPart ;\\n  sh:property [\\n        sh:path cx-diag:provisionedBy ;\\n        sh:hasValue <urn:bpn:legal:BPNL00000003COJN> ;\\n    ] ;\\n\",\n" +

--- a/agent-plane/agentplane-azure-vault/README.md
+++ b/agent-plane/agentplane-azure-vault/README.md
@@ -54,7 +54,7 @@ mvn -s ../../../settings.xml install -Pwith-docker-image
 Alternatively, after a sucessful [build](#building) the docker image of the Agent Plane is created using
 
 ```console
-docker build -t tractusx//agentplane-azure-vault:1.11.16-SNAPSHOT -f src/main/docker/Dockerfile .
+docker build -t tractusx//agentplane-azure-vault:1.11.16 -f src/main/docker/Dockerfile .
 ```
 
 To run the docker image, you could invoke this command

--- a/agent-plane/agentplane-azure-vault/pom.xml
+++ b/agent-plane/agentplane-azure-vault/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.tractusx.agents.edc</groupId>
         <artifactId>agent-plane</artifactId>
-        <version>1.11.16-SNAPSHOT</version>
+        <version>1.11.16</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/agent-plane/agentplane-hashicorp/README.md
+++ b/agent-plane/agentplane-hashicorp/README.md
@@ -54,7 +54,7 @@ mvn -s ../../../settings.xml install -Pwith-docker-image
 Alternatively, after a sucessful [build](#building) the docker image of the Agent Plane is created using
 
 ```console
-docker build -t tractusx/agentplane-hashicorp:1.11.16-SNAPSHOT -f src/main/docker/Dockerfile .
+docker build -t tractusx/agentplane-hashicorp:1.11.16 -f src/main/docker/Dockerfile .
 ```
 
 To run the docker image, you could invoke this command
@@ -66,7 +66,7 @@ docker run -p 8082:8082 \
   -v $(pwd)/resources/dataplane.properties:/app/configuration.properties \
   -v $(pwd)/resources/opentelemetry.properties:/app/opentelemetry.properties \
   -v $(pwd)/resources/logging.properties:/app/logging.properties \
-  tractusx/agentplane-hashicorp:1.11.16-SNAPSHOT
+  tractusx/agentplane-hashicorp:1.11.16
 ````
 
 Afterwards, you should be able to access the [local SparQL endpoint](http://localhost:8082/api/agent) via

--- a/agent-plane/agentplane-hashicorp/pom.xml
+++ b/agent-plane/agentplane-hashicorp/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.tractusx.agents.edc</groupId>
         <artifactId>agent-plane</artifactId>
-        <version>1.11.16-SNAPSHOT</version>
+        <version>1.11.16</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/agent-plane/pom.xml
+++ b/agent-plane/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.eclipse.tractusx.agents</groupId>
         <artifactId>edc</artifactId>
-        <version>1.11.16-SNAPSHOT</version>
+        <version>1.11.16</version>
         <relativePath>../pom.xml</relativePath>    
     </parent>
     <name>Tractus-X EDC Agent Plane</name>

--- a/charts/agent-connector-azure-vault/Chart.yaml
+++ b/charts/agent-connector-azure-vault/Chart.yaml
@@ -42,12 +42,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.11.16-SNAPSHOT
+version: 1.11.16
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.11.16-SNAPSHOT"
+appVersion: "1.11.16"
 home: https://github.com/eclipse-tractusx/knowledge-agents-edc/
 sources:
   - https://github.com/eclipse-tractusx/knowledge-agents-edc/tree/main/charts/agent-connector

--- a/charts/agent-connector-azure-vault/README.md
+++ b/charts/agent-connector-azure-vault/README.md
@@ -20,7 +20,7 @@
 
 # agent-connector-azure-vault
 
-![Version: 1.11.16-SNAPSHOT](https://img.shields.io/badge/Version-1.9.8--SNAPSHOT-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.11.16-SNAPSHOT](https://img.shields.io/badge/AppVersion-1.9.5--SNAPSHOT-informational?style=flat-square)
+![Version: 1.11.16](https://img.shields.io/badge/Version-1.9.8--SNAPSHOT-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.11.16](https://img.shields.io/badge/AppVersion-1.9.5--SNAPSHOT-informational?style=flat-square)
 
 A Helm chart for an Agent-Enabled Tractus-X Eclipse Data Space Connector configured against Azure Vault. This is a variant of [the Tractus-X Azure Vault Connector Helm Chart](https://github.com/eclipse-tractusx/tractusx-edc/tree/main/charts/tractusx-connector-azure-vault) which allows
 to deal with several data (and agent) planes. The connector deployment consists of at least two runtime consists of a
@@ -112,7 +112,7 @@ Combined, run this shell command to start the in-memory Tractus-X EDC runtime:
 
 ```shell
 helm repo add eclipse-tractusx https://eclipse-tractusx.github.io/charts/dev
-helm install my-release eclipse-tractusx/agent-connector-azure-vault --version 1.11.16-SNAPSHOT\
+helm install my-release eclipse-tractusx/agent-connector-azure-vault --version 1.11.16\
      -f <path-to>/tractusx-connector-azure-vault-test.yaml \
      --set vault.azure.name=$AZURE_VAULT_NAME \
      --set vault.azure.client=$AZURE_CLIENT_ID \

--- a/charts/agent-connector-memory/Chart.yaml
+++ b/charts/agent-connector-memory/Chart.yaml
@@ -42,12 +42,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.11.16-SNAPSHOT
+version: 1.11.16
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.11.16-SNAPSHOT"
+appVersion: "1.11.16"
 home: https://github.com/eclipse-tractusx/knowledge-agents-edc/
 sources:
   - https://github.com/eclipse-tractusx/knowledge-agents-edc/tree/main/charts/agent-connector

--- a/charts/agent-connector-memory/README.md
+++ b/charts/agent-connector-memory/README.md
@@ -20,7 +20,7 @@
 
 # agent-connector-memory
 
-![Version: 1.11.16-SNAPSHOT](https://img.shields.io/badge/Version-1.9.8--SNAPSHOT-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.11.16-SNAPSHOT](https://img.shields.io/badge/AppVersion-1.9.5--SNAPSHOT-informational?style=flat-square)
+![Version: 1.11.16](https://img.shields.io/badge/Version-1.9.8--SNAPSHOT-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.11.16](https://img.shields.io/badge/AppVersion-1.9.5--SNAPSHOT-informational?style=flat-square)
 
 A Helm chart for an Agent-Enabled Tractus-X Eclipse Data Space Connector using In-Memory Persistence. This is a variant of [the Tractus-X In-Memory Connector Helm Chart](https://github.com/eclipse-tractusx/tractusx-edc/tree/main/charts/tractusx-connector-memory) which allows
 to deal with several data (and agent) planes. The connector deployment consists of at least two runtime consists of a
@@ -108,7 +108,7 @@ Combined, run this shell command to start the in-memory Tractus-X EDC runtime:
 
 ```shell
 helm repo add eclipse-tractusx https://eclipse-tractusx.github.io/charts/dev
-helm install my-release eclipse-tractusx/agent-connector --version 1.11.16-SNAPSHOT
+helm install my-release eclipse-tractusx/agent-connector --version 1.11.16
 ```
 
 ## Maintainers

--- a/charts/agent-connector/Chart.yaml
+++ b/charts/agent-connector/Chart.yaml
@@ -41,12 +41,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.11.16-SNAPSHOT
+version: 1.11.16
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.11.16-SNAPSHOT"
+appVersion: "1.11.16"
 home: https://github.com/eclipse-tractusx/knowledge-agents-edc/
 sources:
   - https://github.com/eclipse-tractusx/knowledge-agents-edc/tree/main/charts/agent-connector

--- a/charts/agent-connector/README.md
+++ b/charts/agent-connector/README.md
@@ -20,7 +20,7 @@
 
 # agent-connector
 
-![Version: 1.11.16-SNAPSHOT](https://img.shields.io/badge/Version-1.9.8--SNAPSHOT-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.11.16-SNAPSHOT](https://img.shields.io/badge/AppVersion-1.9.5--SNAPSHOT-informational?style=flat-square)
+![Version: 1.11.16](https://img.shields.io/badge/Version-1.9.8--SNAPSHOT-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.11.16](https://img.shields.io/badge/AppVersion-1.9.5--SNAPSHOT-informational?style=flat-square)
 
 A Helm chart for an Agent-Enabled Tractus-X Eclipse Data Space Connector. This is a variant of [the Tractus-X Connector Helm Chart](https://github.com/eclipse-tractusx/tractusx-edc/tree/main/charts/tractusx-connector) which allows
 to deal with several data (and agent) planes. The connector deployment consists of at least two runtime consists of a
@@ -108,7 +108,7 @@ Combined, run this shell command to start the in-memory Tractus-X EDC runtime:
 
 ```shell
 helm repo add eclipse-tractusx https://eclipse-tractusx.github.io/charts/dev
-helm install my-release eclipse-tractusx/agent-connector --version 1.11.16-SNAPSHOT
+helm install my-release eclipse-tractusx/agent-connector --version 1.11.16
 ```
 
 ## Maintainers

--- a/common/README.md
+++ b/common/README.md
@@ -57,7 +57,7 @@ add the following dependency to your maven dependencies (gradle should work anal
         <dependency>
           <groupId>org.eclipse.tractusx.edc</groupId>
           <artifactId>auth-jwt</artifactId>
-          <version>1.11.16-SNAPSHOT</version>
+          <version>1.11.16</version>
         </dependency>
     </dependencies>
 </project>

--- a/common/auth-jwt/README.md
+++ b/common/auth-jwt/README.md
@@ -37,7 +37,7 @@ Add the following dependency to your EDC artifact pom:
         <dependency>
             <groupId>org.eclipse.tractusx.agents.edc</groupId>
             <artifactId>auth-jwt</artifactId>
-            <version>1.11.16-SNAPSHOT</version>
+            <version>1.11.16</version>
         </dependency>
 ```
 

--- a/common/auth-jwt/pom.xml
+++ b/common/auth-jwt/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.eclipse.tractusx.agents</groupId>
         <artifactId>edc</artifactId>
-        <version>1.11.16-SNAPSHOT</version>
+        <version>1.11.16</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -76,7 +76,7 @@ dependencies:
   
     - name: agent-connector-memory
       repository: https://eclipse-tractusx.github.io/charts/dev
-      version: 1.11.16-SNAPSHOT
+      version: 1.11.16
       alias: my-connector
 ```
 
@@ -87,7 +87,7 @@ dependencies:
   
     - name: agent-connector-azure-vault
       repository: https://eclipse-tractusx.github.io/charts/dev
-      version: 1.11.16-SNAPSHOT
+      version: 1.11.16
       alias: my-connector
 ```
 
@@ -98,7 +98,7 @@ dependencies:
   
     - name: agent-connector
       repository: https://eclipse-tractusx.github.io/charts/dev
-      version: 1.11.16-SNAPSHOT
+      version: 1.11.16
       alias: my-connector
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.eclipse.tractusx.agents</groupId>
     <artifactId>edc</artifactId>
-    <version>1.11.16-SNAPSHOT</version>
+    <version>1.11.16</version>
     <packaging>pom</packaging>
     <name>Tractus-X Knowledge Agents EDC Extensions</name>
     <description>EDC-Related Artifacts for Federated Procedure Calls</description>

--- a/upgrade_version.sh
+++ b/upgrade_version.sh
@@ -16,7 +16,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-OLD_VERSION=1.11.16-SNAPSHOT
+OLD_VERSION=1.11.16
 echo Upgrading from $OLD_VERSION to $1
 PATTERN=s/$OLD_VERSION/$1/g
 LC_ALL=C


### PR DESCRIPTION
<!--
 * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Apache License, Version 2.0 which is available at
 * https://www.apache.org/licenses/LICENSE-2.0.
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 * License for the specific language governing permissions and limitations
 * under the License.
 *
 * SPDX-License-Identifier: Apache-2.0
-->

## WHAT

Remove SNAPSHOT suffix from versions

## WHY

Prepare 24.03 release

## FURTHER NOTES

