### PR TITLE
fix: introduce url & header checking from the config.

### DIFF
--- a/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/AgentConfig.java
+++ b/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/AgentConfig.java
@@ -89,6 +89,10 @@ public class AgentConfig {
 
     public static final String SERVICE_DENY_ASSET_PROPERTY = "cx.agent.service.asset.deny";
     public static final String DEFAULT_SERVICE_DENY_ASSET_PATTERN = "^$";
+    public static final String SERVICE_ALLOW_CONNECTOR_PROPERTY = "cx.agent.service.connector.allow";
+    public static final String DEFAULT_SERVICE_ALLOW_CONNECTOR_PATTERN = "https://.*";
+    public static final String SERVICE_DENY_CONNECTOR_PROPERTY = "cx.agent.service.connector.deny";
+    public static final String DEFAULT_SERVICE_DENY_CONNECTOR_PATTERN = "^$";
 
     public static final String MATCHMAKING_URL = "cx.agent.matchmaking";
 
@@ -100,6 +104,11 @@ public class AgentConfig {
     protected final Pattern serviceAssetAllowPattern;
     protected final Pattern serviceAssetDenyPattern;
     protected static final Pattern ASSET_REFERENCE_PATTERN = Pattern.compile("((?<url>[^#]+)#)?(?<asset>.+)");
+    protected final Pattern connectorAllowPattern;
+    protected final Pattern connectorDenyPattern;
+
+    public static final Pattern PARAMETER_KEY_ALLOW = Pattern.compile("^(?<param>(?!asset$)[^&?=]+)$");
+    public static final Pattern PARAMETER_VALUE_ALLOW = Pattern.compile("^(?<value>[^&]+)$");
 
     /**
      * references to EDC services
@@ -120,6 +129,8 @@ public class AgentConfig {
         serviceDenyPattern = Pattern.compile(config.getString(SERVICE_DENY_PROPERTY, DEFAULT_SERVICE_DENY_PATTERN));
         serviceAssetAllowPattern = Pattern.compile(config.getString(SERVICE_ALLOW_ASSET_PROPERTY, DEFAULT_SERVICE_ALLOW_ASSET_PATTERN));
         serviceAssetDenyPattern = Pattern.compile(config.getString(SERVICE_DENY_ASSET_PROPERTY, DEFAULT_SERVICE_DENY_ASSET_PATTERN));
+        connectorAllowPattern = Pattern.compile(config.getString(SERVICE_ALLOW_CONNECTOR_PROPERTY, DEFAULT_SERVICE_ALLOW_CONNECTOR_PATTERN));
+        connectorDenyPattern = Pattern.compile(config.getString(SERVICE_DENY_CONNECTOR_PROPERTY, DEFAULT_SERVICE_DENY_CONNECTOR_PATTERN));
     }
 
     /**
@@ -172,7 +183,11 @@ public class AgentConfig {
      * @return uri of the control plane management endpoint (without concrete api)
      */
     public String getControlPlaneManagementUrl() {
-        return config.getString(CONTROL_PLANE_MANAGEMENT, null);
+        String url = config.getString(CONTROL_PLANE_MANAGEMENT, null);
+        if (url != null && connectorAllowPattern.matcher(url).matches() && !connectorDenyPattern.matcher(url).matches()) {
+            return url;
+        }
+        return null;
     }
 
     /**
@@ -181,7 +196,11 @@ public class AgentConfig {
      * @return uri of the control plane management endpoint (without concrete api)
      */
     public String getControlPlaneManagementProviderUrl() {
-        return config.getString(CONTROL_PLANE_MANAGEMENT_PROVIDER, config.getString(CONTROL_PLANE_MANAGEMENT, null));
+        String url = config.getString(CONTROL_PLANE_MANAGEMENT_PROVIDER, config.getString(CONTROL_PLANE_MANAGEMENT, null));
+        if (url != null && connectorAllowPattern.matcher(url).matches() && !connectorDenyPattern.matcher(url).matches()) {
+            return url;
+        }
+        return null;
     }
 
     /**
@@ -190,7 +209,11 @@ public class AgentConfig {
      * @return uri of the control plane ids endpoint (without concrete api)
      */
     public String getControlPlaneIdsUrl() {
-        return config.getString(CONTROL_PLANE_IDS, null);
+        String url = config.getString(CONTROL_PLANE_IDS, null);
+        if (url != null && connectorAllowPattern.matcher(url).matches() && !connectorDenyPattern.matcher(url).matches()) {
+            return url;
+        }
+        return null;
     }
 
     /**
@@ -201,7 +224,7 @@ public class AgentConfig {
     public Map<String, String> getControlPlaneManagementHeaders() {
         String key = config.getString(CONTROL_PLANE_AUTH_HEADER, "X-Api-Key");
         String value = config.getString(CONTROL_PLANE_AUTH_VALUE, null);
-        if (key != null && value != null) {
+        if (key != null && PARAMETER_KEY_ALLOW.matcher(key).matches() && value != null && PARAMETER_VALUE_ALLOW.matcher(value).matches()) {
             return Map.of(key, value);
         }
         return Map.of();
@@ -397,7 +420,12 @@ public class AgentConfig {
      * @return URL for Matchmaking Agent REST call
      */
     public String getMatchmakingAgentUrl() {
-        return config.getString(MATCHMAKING_URL, null);
+        String url =  config.getString(MATCHMAKING_URL, null);
+        if (url != null && connectorAllowPattern.matcher(url).matches() && !connectorDenyPattern.matcher(url).matches()) {
+            return url;
+        }
+        return null;
+
     }
 
 }

--- a/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/http/DelegationServiceImpl.java
+++ b/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/http/DelegationServiceImpl.java
@@ -180,12 +180,11 @@ public class DelegationServiceImpl implements DelegationService {
         requestBuilder.post(okhttp3.RequestBody.create(request.getInputStream().readAllBytes(), parsedContentType));
 
         var newRequest = requestBuilder.build();
-        
+
         return new DelegationResponse(sendRequest(newRequest, response), Response.status(response.getStatus()).build());
     }
 
-    protected static final Pattern PARAMETER_KEY_ALLOW = Pattern.compile("^(?<param>(?!asset$)[^&?=]+)$");
-    protected static final Pattern PARAMETER_VALUE_ALLOW = Pattern.compile("^(?<value>[^&]+)$");
+
 
     /**
      * computes the url to target the given data plane
@@ -210,11 +209,11 @@ public class DelegationServiceImpl implements DelegationService {
         HttpUrl.Builder httpBuilder = Objects.requireNonNull(okhttp3.HttpUrl.parse(url)).newBuilder();
         for (Map.Entry<String, List<String>> param : uri.getQueryParameters().entrySet()) {
             String key = param.getKey();
-            Matcher keyMatcher = PARAMETER_KEY_ALLOW.matcher(key);
+            Matcher keyMatcher = AgentConfig.PARAMETER_KEY_ALLOW.matcher(key);
             if (keyMatcher.matches()) {
                 String recodeKey = HttpUtils.urlEncodeParameter(keyMatcher.group("param"));
                 for (String value : param.getValue()) {
-                    Matcher valueMatcher = PARAMETER_VALUE_ALLOW.matcher(value);
+                    Matcher valueMatcher = AgentConfig.PARAMETER_VALUE_ALLOW.matcher(value);
                     if (valueMatcher.matches()) {
                         String recodeValue = HttpUtils.urlEncodeParameter(valueMatcher.group("value"));
                         httpBuilder = httpBuilder.addQueryParameter(recodeKey, recodeValue);
@@ -248,7 +247,7 @@ public class DelegationServiceImpl implements DelegationService {
             if (!myResponse.isSuccessful()) {
                 monitor.warning(String.format("Data plane call was not successful: %s", myResponse.code()));
             }
-            
+
             Optional<List<CatenaxWarning>> warnings = Optional.empty();
 
             var body = myResponse.body();


### PR DESCRIPTION
<!--
 * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Apache License, Version 2.0 which is available at
 * https://www.apache.org/licenses/LICENSE-2.0.
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 * License for the specific language governing permissions and limitations
 * under the License.
 *
 * SPDX-License-Identifier: Apache-2.0
-->

## WHAT

Improves url and header checking in AgentConfig.

## WHY

CodeQL may complain about some potential SSF traps.

## FURTHER NOTES

Wrt to sanitizing other dynamic SSF sources which CodeQL may not correctly detect, please have a look at:
- https://github.com/eclipse-tractusx/knowledge-agents-edc/blob/1d51fed97cd2aa379d452f54b5a9175eb65ab72e/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/http/DelegationServiceImpl.java#L214 ff
- https://github.com/eclipse-tractusx/knowledge-agents-edc/blob/1d51fed97cd2aa379d452f54b5a9175eb65ab72e/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/http/DelegationServiceImpl.java#L218 ff


