### PR TITLE
fix|chore: e2e test issues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,7 +142,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=1.13.21-SNAPSHOT,enable=${{ github.event.inputs.deploy_docker == 'true' || github.ref == format('refs/heads/{0}', 'main') }}
+            type=raw,value=1.13.22-SNAPSHOT,enable=${{ github.event.inputs.deploy_docker == 'true' || github.ref == format('refs/heads/{0}', 'main') }}
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 
       - name: Agent Plane Hashicorp Container Build and push
@@ -180,7 +180,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=1.13.21-SNAPSHOT,enable=${{ github.event.inputs.deploy_docker == 'true' || github.ref == format('refs/heads/{0}', 'main') }}
+            type=raw,value=1.13.22-SNAPSHOT,enable=${{ github.event.inputs.deploy_docker == 'true' || github.ref == format('refs/heads/{0}', 'main') }}
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 
       - name: Agent Plane Azure Vault Container Build and push

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,13 +24,14 @@ All notable changes to this product will be documented in this file.
 
 # Released
 
-## [1.13.21] - 2024-07-15
+## [1.13.22] - 2024-07-29
 
 ### Added
 
 ### Changed
 
 - Adapted to Tractus-X EDC 0.7.3
+- Add connector url allowance patterns to the chart values for easier configuration.
 
 ## [1.12.19] - 2024-05-17
 

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -267,8 +267,8 @@ maven/mavencentral/org.eclipse.jetty/jetty-util/11.0.21, EPL-2.0 OR Apache-2.0, 
 maven/mavencentral/org.eclipse.jetty/jetty-webapp/11.0.21, EPL-2.0 OR Apache-2.0, approved, rt.jetty
 maven/mavencentral/org.eclipse.jetty/jetty-xml/11.0.21, EPL-2.0 OR Apache-2.0, approved, rt.jetty
 maven/mavencentral/org.eclipse.parsson/parsson/1.1.6, EPL-2.0, approved, ee4j.parsson
-maven/mavencentral/org.eclipse.tractusx.agents.edc.agent-plane/agent-plane-protocol/1.13.21-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.eclipse.tractusx.edc/auth-jwt/1.13.21-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx.agents.edc.agent-plane/agent-plane-protocol/1.13.22-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx.edc/auth-jwt/1.13.22-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
 maven/mavencentral/org.eclipse.tractusx.edc/core-spi/0.7.3, Apache-2.0, approved, automotive.tractusx
 maven/mavencentral/org.eclipse.tractusx.edc/core-utils/0.7.3, Apache-2.0, approved, automotive.tractusx
 maven/mavencentral/org.eclipse.tractusx.edc/data-plane-migration/0.7.3, Apache-2.0, approved, automotive.tractusx

--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ kubectl wait --namespace ingress-nginx \
   --selector=app.kubernetes.io/component=controller \
   --timeout=90s
 # transfer images
-kind load docker-image docker.io/tractusx/agentplane-hashicorp:1.13.21-SNAPSHOT --name ka
-kind load docker-image docker.io/tractusx/agentplane-azure-vault:1.13.21-SNAPSHOT --name ka
+kind load docker-image docker.io/tractusx/agentplane-hashicorp:1.13.22-SNAPSHOT --name ka
+kind load docker-image docker.io/tractusx/agentplane-azure-vault:1.13.22-SNAPSHOT --name ka
 # run chart testing
 ct install --charts charts/agent-plane
 ct install --charts charts/agent-plane-azure-vault   

--- a/agent-plane/README.md
+++ b/agent-plane/README.md
@@ -66,10 +66,10 @@ mvn package -Pwith-docker-image
 Alternatively, after a successful build, you can invoke docker yourself 
 
 ```console
-docker build -t tractusx/agentplane-azure-vault:1.13.21-SNAPSHOT -f agentplane-azure-vault/src/main/docker/Dockerfile .
+docker build -t tractusx/agentplane-azure-vault:1.13.22-SNAPSHOT -f agentplane-azure-vault/src/main/docker/Dockerfile .
 ```
 
 ```console
-docker build -t tractusx/agentplane-hashicorp:1.13.21-SNAPSHOT -f agentplane-hashicorp/src/main/docker/Dockerfile .
+docker build -t tractusx/agentplane-hashicorp:1.13.22-SNAPSHOT -f agentplane-hashicorp/src/main/docker/Dockerfile .
 ```
 

--- a/agent-plane/agent-plane-protocol/README.md
+++ b/agent-plane/agent-plane-protocol/README.md
@@ -64,7 +64,7 @@ Add the following dependency to your data-plane artifact pom:
         <dependency>
             <groupId>org.eclipse.tractusx.agents.edc</groupId>
             <artifactId>agent-plane-protocol</artifactId>
-            <version>1.13.21-SNAPSHOT</version>
+            <version>1.13.22-SNAPSHOT</version>
         </dependency>
 ```
 

--- a/agent-plane/agent-plane-protocol/pom.xml
+++ b/agent-plane/agent-plane-protocol/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.tractusx.agents.edc</groupId>
         <artifactId>agent-plane</artifactId>
-        <version>1.13.21-SNAPSHOT</version>
+        <version>1.13.22-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/AgentExtension.java
+++ b/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/AgentExtension.java
@@ -169,14 +169,16 @@ public class AgentExtension implements ServiceExtension {
                 monitor,
                 httpRequestFactory,
                 processor,
-                skillStore);
+                skillStore,
+                typeManager);
         AgentSourceFactory skillSourceFactory = new AgentSourceFactory(AgentProtocol.SKILL_HTTP.getProtocolId(),
                 edcHttpClient,
                 new AgentSourceRequestParamsSupplier(vault, typeManager, config, monitor),
                 monitor,
                 httpRequestFactory,
                 processor,
-                skillStore);
+                skillStore,
+                typeManager);
         pipelineService.registerFactory(sparqlSourceFactory);
         pipelineService.registerFactory(skillSourceFactory);
 

--- a/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/http/AgentHttpAction.java
+++ b/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/http/AgentHttpAction.java
@@ -19,14 +19,19 @@ package org.eclipse.tractusx.agents.edc.http;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import jakarta.ws.rs.BadRequestException;
 import org.apache.http.HttpStatus;
 import org.apache.jena.fuseki.servlets.HttpAction;
 import org.apache.jena.fuseki.system.ActionCategory;
+import org.eclipse.tractusx.agents.edc.Tuple;
 import org.eclipse.tractusx.agents.edc.TupleSet;
 import org.slf4j.Logger;
 
 import java.net.URLDecoder;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Stack;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -37,10 +42,11 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 
 /**
- * HttpAction which may either contain
- * a query or a predefined skill. In each case
+ * HttpAction is a wrapper around a request/response 
+ * which may either contain a query or a predefined skill. In each case
  * the parameterization/input binding can be done either by
  * url parameters, by a binding set body or both.
+ * It contains also helper code to bind parameterized queries.
  */
 public class AgentHttpAction extends HttpAction {
     final String skill;
@@ -116,25 +122,35 @@ public class AgentHttpAction extends HttpAction {
     }
 
     /**
-     * parses the body
+     * parses a given binding into a tupleset
+     *
+     * @param resultSet new binding spec
+     * @param tuples existing bindings
+     */
+    public static void parseBinding(JsonNode resultSet, TupleSet tuples) throws Exception {
+        ArrayNode bindings = ((ArrayNode) resultSet.get("results").get("bindings"));
+        for (int count = 0; count < bindings.size(); count++) {
+            TupleSet ts = new TupleSet();
+            JsonNode binding = bindings.get(count);
+            Iterator<String> vars = binding.fieldNames();
+            while (vars.hasNext()) {
+                String var = vars.next();
+                JsonNode value = binding.get(var).get("value");
+                ts.add(var, value.textValue());
+            }
+            tuples.merge(ts);
+        }
+    }
+
+    /**
+     * parses the body of the request as an input binding, if
+     * the content type is hinting to a sparql resultset
      */
     protected void parseBody(HttpServletRequest request, HttpServletResponse response) {
         if (RESULTSET_CONTENT_TYPE.equals(request.getContentType())) {
             ObjectMapper om = new ObjectMapper();
             try {
-                JsonNode bindingSet = om.readTree(request.getInputStream());
-                ArrayNode bindings = ((ArrayNode) bindingSet.get("results").get("bindings"));
-                for (int count = 0; count < bindings.size(); count++) {
-                    TupleSet ts = new TupleSet();
-                    JsonNode binding = bindings.get(count);
-                    Iterator<String> vars = binding.fieldNames();
-                    while (vars.hasNext()) {
-                        String var = vars.next();
-                        JsonNode value = binding.get(var).get("value");
-                        ts.add(var, value.textValue());
-                    }
-                    tupleSet.merge(ts);
-                }
+                parseBinding(om.readTree(request.getInputStream()), tupleSet);
             } catch (Exception e) {
                 response.setStatus(HttpStatus.SC_BAD_REQUEST);
             }
@@ -166,5 +182,84 @@ public class AgentHttpAction extends HttpAction {
      */
     public TupleSet getInputBindings() {
         return tupleSet;
+    }
+
+    /**
+     * helper method to bind a given tupleset to a parameterized query
+     *
+     * @param query the parameterized query
+     * @param bindings the tupleset to bind
+     * @return bound query
+     */
+    public static String bind(String query, TupleSet bindings) throws Exception {
+        Pattern tuplePattern = Pattern.compile("\\([^()]*\\)");
+        Pattern variablePattern = Pattern.compile("@(?<name>[a-zA-Z0-9]+)");
+        Matcher tupleMatcher = tuplePattern.matcher(query);
+        StringBuilder replaceQuery = new StringBuilder();
+        int lastStart = 0;
+
+        //
+        // First find parameterized tuple appearances. Each tuple appearance is
+        // cloned for each bound "row"
+        //
+        while (tupleMatcher.find()) {
+            replaceQuery.append(query.substring(lastStart, tupleMatcher.start()));
+            String otuple = tupleMatcher.group(0);
+            Matcher variableMatcher = variablePattern.matcher(otuple);
+            List<String> variables = new java.util.ArrayList<>();
+            while (variableMatcher.find()) {
+                variables.add(variableMatcher.group("name"));
+            }
+            if (variables.size() > 0) {
+                boolean isFirst = true;
+                Collection<Tuple> tuples = bindings.getTuples(variables.toArray(new String[0]));
+                for (Tuple rtuple : tuples) {
+                    if (isFirst) {
+                        isFirst = false;
+                    } else {
+                        replaceQuery.append(" ");
+                    }
+                    String newTuple = otuple;
+                    for (String key : rtuple.getVariables()) {
+                        newTuple = newTuple.replace("@" + key, rtuple.get(key));
+                    }
+                    replaceQuery.append(newTuple);
+                }
+            } else {
+                replaceQuery.append(otuple);
+            }
+            lastStart = tupleMatcher.end();
+        }
+        replaceQuery.append(query.substring(lastStart));
+
+        //
+        // Replacing "global" variables appearing not in a tuple expression.
+        // This cannot be done for all bindings, but only the
+        // very first one
+        //
+        String queryString =  replaceQuery.toString();
+
+        Matcher variableMatcher = variablePattern.matcher(queryString);
+        List<String> variables = new java.util.ArrayList<>();
+        while (variableMatcher.find()) {
+            variables.add(variableMatcher.group("name"));
+        }
+        try {
+            Collection<Tuple> tuples = bindings.getTuples(variables.toArray(new String[0]));
+            if (tuples.size() == 0 && variables.size() > 0) {
+                throw new BadRequestException(String.format("Error: Got variables %s on top-level but no bindings.", Arrays.toString(variables.toArray())));
+            } else if (tuples.size() > 1) {
+                System.err.println(String.format("Warning: Got %s tuples for top-level bindings of variables %s. Using only the first one.", tuples.size(), Arrays.toString(variables.toArray())));
+            }
+            if (tuples.size() > 0) {
+                Tuple rtuple = tuples.iterator().next();
+                for (String key : rtuple.getVariables()) {
+                    queryString = queryString.replace("@" + key, rtuple.get(key));
+                }
+            }
+        } catch (Exception e) {
+            throw new BadRequestException(String.format("Error: Could not bind variables"), e);
+        }
+        return queryString;
     }
 }

--- a/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/http/transfer/AgentSource.java
+++ b/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/http/transfer/AgentSource.java
@@ -20,6 +20,7 @@ import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
+import okio.Buffer;
 import org.eclipse.edc.connector.dataplane.http.params.HttpRequestFactory;
 import org.eclipse.edc.connector.dataplane.http.spi.HttpRequestParams;
 import org.eclipse.edc.connector.dataplane.spi.pipeline.DataSource;
@@ -137,10 +138,12 @@ public class AgentSource implements DataSource {
                         }
                         String query = skillText.get();
                         okhttp3.Request tempRequest = this.requestFactory.toRequest(this.params);
-                        if (tempRequest.body() != null && tempRequest.body().contentType().toString() == AgentHttpAction.RESULTSET_CONTENT_TYPE) {
+                        if (tempRequest.body() != null && AgentHttpAction.RESULTSET_CONTENT_TYPE.equals(tempRequest.body().contentType().toString())) {
                             TupleSet bindings = new TupleSet();
                             try {
-                                AgentHttpAction.parseBinding(typeManager.getMapper().readTree(tempRequest.body().toString()), bindings);
+                                Buffer buffer = new Buffer();
+                                tempRequest.body().writeTo(buffer);
+                                AgentHttpAction.parseBinding(typeManager.getMapper().readTree(buffer.readByteArray()), bindings);
                                 query = AgentHttpAction.bind(query, bindings);
                             } catch (Exception e) {
                                 return StreamResult.error(String.format("The query could not be bound to the given input tupleset.", e));
@@ -219,10 +222,12 @@ public class AgentSource implements DataSource {
                         }
                         String query = skillText.get();
                         okhttp3.Request tempRequest = this.requestFactory.toRequest(this.params);
-                        if (tempRequest.body() != null && tempRequest.body().contentType().toString() == AgentHttpAction.RESULTSET_CONTENT_TYPE) {
+                        if (tempRequest.body() != null && AgentHttpAction.RESULTSET_CONTENT_TYPE.equals(tempRequest.body().contentType().toString())) {
                             TupleSet bindings = new TupleSet();
                             try {
-                                AgentHttpAction.parseBinding(typeManager.getMapper().readTree(tempRequest.body().toString()), bindings);
+                                Buffer buffer = new Buffer();
+                                tempRequest.body().writeTo(buffer);
+                                AgentHttpAction.parseBinding(typeManager.getMapper().readTree(buffer.readByteArray()), bindings);
                                 query = AgentHttpAction.bind(query, bindings);
                             } catch (Exception e) {
                                 return StreamResult.error(String.format("The query could not be bound to the given input tupleset.", e));

--- a/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/http/transfer/AgentSource.java
+++ b/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/http/transfer/AgentSource.java
@@ -25,10 +25,13 @@ import org.eclipse.edc.connector.dataplane.http.spi.HttpRequestParams;
 import org.eclipse.edc.connector.dataplane.spi.pipeline.DataSource;
 import org.eclipse.edc.connector.dataplane.spi.pipeline.StreamResult;
 import org.eclipse.edc.http.spi.EdcHttpClient;
+import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 import org.eclipse.tractusx.agents.edc.AgentConfig;
 import org.eclipse.tractusx.agents.edc.SkillDistribution;
 import org.eclipse.tractusx.agents.edc.SkillStore;
+import org.eclipse.tractusx.agents.edc.TupleSet;
+import org.eclipse.tractusx.agents.edc.http.AgentHttpAction;
 import org.eclipse.tractusx.agents.edc.sparql.SparqlQueryProcessor;
 import org.jetbrains.annotations.NotNull;
 
@@ -70,6 +73,8 @@ public class AgentSource implements DataSource {
     protected SkillStore skillStore;
 
     protected DataFlowStartMessage request;
+
+    protected TypeManager typeManager;
 
     protected String matchmakingAgentUrl;
 
@@ -114,6 +119,13 @@ public class AgentSource implements DataSource {
                     SkillDistribution distribution = skillStore.getDistribution(asset);
                     String params = request.getProperties().get(AgentSourceHttpParamsDecorator.QUERY_PARAMS);
                     SkillDistribution runMode = SkillDistribution.ALL;
+                    // if we have no distribution constraints, let the runMode decide
+                    if (distribution == SkillDistribution.ALL) {
+                        distribution = runMode;
+                    } else if (runMode == SkillDistribution.ALL) {
+                        // if we have no runMode constraints, let the distribution decide
+                        runMode = distribution;
+                    }
                     if (params.contains("runMode=provider") || params.contains("runMode=PROVIDER")) {
                         runMode = SkillDistribution.PROVIDER;
                     } else if (params.contains("runMode=consumer") || params.contains("runMode=CONSUMER")) {
@@ -123,7 +135,18 @@ public class AgentSource implements DataSource {
                         if (distribution == SkillDistribution.PROVIDER) {
                             return StreamResult.error(String.format("Run distribution of skill %s should be consumer, but was set to provider only.", asset));
                         }
-                        return StreamResult.success(Stream.of(new AgentPart("application/sparql-query", skillText.get().getBytes())));
+                        String query = skillText.get();
+                        okhttp3.Request tempRequest = this.requestFactory.toRequest(this.params);
+                        if (tempRequest.body() != null && tempRequest.body().contentType().toString() == AgentHttpAction.RESULTSET_CONTENT_TYPE) {
+                            TupleSet bindings = new TupleSet();
+                            try {
+                                AgentHttpAction.parseBinding(typeManager.getMapper().readTree(tempRequest.body().toString()), bindings);
+                                query = AgentHttpAction.bind(query, bindings);
+                            } catch (Exception e) {
+                                return StreamResult.error(String.format("The query could not be bound to the given input tupleset.", e));
+                            }
+                        }
+                        return StreamResult.success(Stream.of(new AgentPart("application/sparql-query", query.getBytes())));
                     } else if (runMode == SkillDistribution.PROVIDER && distribution == SkillDistribution.CONSUMER) {
                         return StreamResult.error(String.format("Run distribution of skill %s should be provider, but was set to consumer only.", asset));
                     }
@@ -183,11 +206,29 @@ public class AgentSource implements DataSource {
                     } else if (params.contains("runMode=consumer") || params.contains("runMode=CONSUMER")) {
                         runMode = SkillDistribution.CONSUMER;
                     }
+                    // if we have no distribution constraints, let the runMode decide
+                    if (distribution == SkillDistribution.ALL) {
+                        distribution = runMode;
+                    } else if (runMode == SkillDistribution.ALL) {
+                        // if we have no runMode constraints, let the distribution decide
+                        runMode = distribution;
+                    }
                     if (runMode == SkillDistribution.CONSUMER) {
                         if (distribution == SkillDistribution.PROVIDER) {
                             return StreamResult.error(String.format("Run distribution of skill %s should be consumer, but was set to provider only.", asset));
                         }
-                        return StreamResult.success(Stream.of(new AgentPart("application/sparql-query", skillText.get().getBytes())));
+                        String query = skillText.get();
+                        okhttp3.Request tempRequest = this.requestFactory.toRequest(this.params);
+                        if (tempRequest.body() != null && tempRequest.body().contentType().toString() == AgentHttpAction.RESULTSET_CONTENT_TYPE) {
+                            TupleSet bindings = new TupleSet();
+                            try {
+                                AgentHttpAction.parseBinding(typeManager.getMapper().readTree(tempRequest.body().toString()), bindings);
+                                query = AgentHttpAction.bind(query, bindings);
+                            } catch (Exception e) {
+                                return StreamResult.error(String.format("The query could not be bound to the given input tupleset.", e));
+                            }
+                        }
+                        return StreamResult.success(Stream.of(new AgentPart("application/sparql-query", query.getBytes())));
                     } else if (runMode == SkillDistribution.PROVIDER && distribution == SkillDistribution.CONSUMER) {
                         return StreamResult.error(String.format("Run distribution of skill %s should be provider, but was set to consumer only.", asset));
                     }
@@ -298,6 +339,11 @@ public class AgentSource implements DataSource {
 
         public AgentSource.Builder matchmakingAgentUrl(String matchmakingAgentUrl) {
             dataSource.matchmakingAgentUrl = matchmakingAgentUrl;
+            return this;
+        }
+
+        public AgentSource.Builder typeManager(TypeManager typeManager) {
+            dataSource.typeManager = typeManager;
             return this;
         }
 

--- a/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/http/transfer/AgentSourceFactory.java
+++ b/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/http/transfer/AgentSourceFactory.java
@@ -21,6 +21,7 @@ import org.eclipse.edc.connector.dataplane.http.spi.HttpDataAddress;
 import org.eclipse.edc.connector.dataplane.spi.pipeline.DataSource;
 import org.eclipse.edc.http.spi.EdcHttpClient;
 import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 import org.eclipse.tractusx.agents.edc.SkillStore;
 import org.eclipse.tractusx.agents.edc.sparql.SparqlQueryProcessor;
@@ -36,6 +37,7 @@ public class AgentSourceFactory extends org.eclipse.edc.connector.dataplane.http
     final SparqlQueryProcessor processor;
     final SkillStore skillStore;
     final HttpRequestFactory requestFactory;
+    final TypeManager typeManager;
     final String protocol;
 
     /**
@@ -47,8 +49,9 @@ public class AgentSourceFactory extends org.eclipse.edc.connector.dataplane.http
      * @param requestFactory for outgoing calls
      * @param processor the query processor/sparql engine
      * @param skillStore store for skills
+     * @param typeManager type manager
      */
-    public AgentSourceFactory(String protocol, EdcHttpClient httpClient, AgentSourceRequestParamsSupplier supplier, Monitor monitor, HttpRequestFactory requestFactory, SparqlQueryProcessor processor, SkillStore skillStore) {
+    public AgentSourceFactory(String protocol, EdcHttpClient httpClient, AgentSourceRequestParamsSupplier supplier, Monitor monitor, HttpRequestFactory requestFactory, SparqlQueryProcessor processor, SkillStore skillStore, TypeManager typeManager) {
         super(httpClient, supplier, monitor, requestFactory);
         this.protocol = protocol;
         this.supplier = supplier;
@@ -57,6 +60,7 @@ public class AgentSourceFactory extends org.eclipse.edc.connector.dataplane.http
         this.skillStore = skillStore;
         this.processor = processor;
         this.requestFactory = requestFactory;
+        this.typeManager = typeManager;
     }
 
     @Override
@@ -93,6 +97,7 @@ public class AgentSourceFactory extends org.eclipse.edc.connector.dataplane.http
                 .name(dataAddress.getName())
                 .params(supplier.provideSourceParams(request))
                 .requestFactory(requestFactory)
+                .typeManager(typeManager)
                 .skillStore(skillStore)
                 .processor(processor)
                 .request(request)

--- a/agent-plane/agent-plane-protocol/src/test/java/org/eclipse/tractusx/agents/edc/service/TestDataspaceSynchronizer.java
+++ b/agent-plane/agent-plane-protocol/src/test/java/org/eclipse/tractusx/agents/edc/service/TestDataspaceSynchronizer.java
@@ -123,7 +123,7 @@ public class TestDataspaceSynchronizer {
         JsonObjectBuilder offerBuilder = Json.createObjectBuilder()
                 .add("@id", "cx-taxo:GraphAsset?test=ExampleAsset")
                 .add("https://w3id.org/edc/v0.0.1/ns/contenttype", "application/json, application/xml")
-                .add("https://w3id.org/catenax/ontology/common#version", "1.13.21-SNAPSHOT")
+                .add("https://w3id.org/catenax/ontology/common#version", "1.13.22-SNAPSHOT")
                 .add("https://w3id.org/catenax/ontology/common#name", "Test Asset")
                 .add("https://w3id.org/catenax/ontology/common#description", "Test Asset for RDF Representation")
                 .add("https://w3id.org/catenax/ontology/common#description@de", "Beispiel Asset für RDF Darstellung")
@@ -212,7 +212,7 @@ public class TestDataspaceSynchronizer {
                 "                },\n" +
                 "                \"dcat:accessService\": \"ddd4b79e-f785-4e71-9fe5-4a177b3ccf54\"\n" +
                 "            },\n" +
-                "            \"edc:version\": \"1.13.21-SNAPSHOT\",\n" +
+                "            \"edc:version\": \"1.13.22-SNAPSHOT\",\n" +
                 "            \"http://www.w3.org/2000/01/rdf-schema#isDefinedBy\": \"<https://w3id.org/catenax/ontology/diagnosis>\",\n" +
                 "            \"edc:name\": \"Diagnostic Trouble Code Catalogue Version 2022\",\n" +
                 "            \"http://www.w3.org/ns/shacl#shapesGraph\": \"@prefix cx-common: <https://w3id.org/catenax/ontology/common#>. \\n@prefix : <https://w3id.org/catenax/taxonomy#GraphAsset?oem=Diagnosis2022&shapeObject=> .\\n@prefix cx-diag: <https://w3id.org/catenax/ontology/diagnosis#> .\\n@prefix owl: <http://www.w3.org/2002/07/owl#> .\\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\\n@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\\n@prefix sh: <http://www.w3.org/ns/shacl#> .\\n\\n:OemDTC rdf:type sh:NodeShape ;\\n  sh:targetClass cx-diag:DTC ;\\n  sh:property [\\n        sh:path cx-diag:provisionedBy ;\\n        sh:hasValue <urn:bpn:legal:BPNL00000003COJN> ;\\n    ] ;\\n  sh:property [\\n        sh:path cx-diag:version ;\\n        sh:hasValue \\\"0\\\"^^xsd:long ;\\n    ] ;\\n  sh:property [\\n        sh:path cx-diag:affects ;\\n        sh:class :OemDiagnosedParts ;\\n    ].\\n\\n:OemDiagnosedParts rdf:type sh:NodeShape ;\\n  sh:targetClass cx-diag:DiagnosedPart ;\\n  sh:property [\\n        sh:path cx-diag:provisionedBy ;\\n        sh:hasValue <urn:bpn:legal:BPNL00000003COJN> ;\\n    ] .\\n\",\n" +

--- a/agent-plane/agentplane-azure-vault/README.md
+++ b/agent-plane/agentplane-azure-vault/README.md
@@ -54,7 +54,7 @@ mvn -s ../../../settings.xml install -Pwith-docker-image
 Alternatively, after a sucessful [build](#building) the docker image of the Agent Plane is created using
 
 ```console
-docker build -t tractusx//agentplane-azure-vault:1.13.21-SNAPSHOT -f src/main/docker/Dockerfile .
+docker build -t tractusx//agentplane-azure-vault:1.13.22-SNAPSHOT -f src/main/docker/Dockerfile .
 ```
 
 To run the docker image, you could invoke this command

--- a/agent-plane/agentplane-azure-vault/pom.xml
+++ b/agent-plane/agentplane-azure-vault/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.tractusx.agents.edc</groupId>
         <artifactId>agent-plane</artifactId>
-        <version>1.13.21-SNAPSHOT</version>
+        <version>1.13.22-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/agent-plane/agentplane-azure-vault/src/main/docker/Dockerfile
+++ b/agent-plane/agentplane-azure-vault/src/main/docker/Dockerfile
@@ -22,7 +22,7 @@ ENV OTEL_AGENT_LOCATION "https://github.com/open-telemetry/opentelemetry-java-in
 
 HEALTHCHECK NONE
 
-RUN apk update && apk add curl=8.5.0-r0 --no-cache
+RUN apk update && apk add curl=8.9.0-r0 --no-cache
 RUN curl -L --proto "=https" -sSf ${OTEL_AGENT_LOCATION} --output /tmp/opentelemetry-javaagent.jar
 
 FROM eclipse-temurin:22-jre-alpine

--- a/agent-plane/agentplane-hashicorp/README.md
+++ b/agent-plane/agentplane-hashicorp/README.md
@@ -54,7 +54,7 @@ mvn -s ../../../settings.xml install -Pwith-docker-image
 Alternatively, after a sucessful [build](#building) the docker image of the Agent Plane is created using
 
 ```console
-docker build -t tractusx/agentplane-hashicorp:1.13.21-SNAPSHOT -f src/main/docker/Dockerfile .
+docker build -t tractusx/agentplane-hashicorp:1.13.22-SNAPSHOT -f src/main/docker/Dockerfile .
 ```
 
 To run the docker image, you could invoke this command
@@ -66,7 +66,7 @@ docker run -p 8082:8082 \
   -v $(pwd)/resources/dataplane.properties:/app/configuration.properties \
   -v $(pwd)/resources/opentelemetry.properties:/app/opentelemetry.properties \
   -v $(pwd)/resources/logging.properties:/app/logging.properties \
-  tractusx/agentplane-hashicorp:1.13.21-SNAPSHOT
+  tractusx/agentplane-hashicorp:1.13.22-SNAPSHOT
 ````
 
 Afterwards, you should be able to access the [local SparQL endpoint](http://localhost:8082/api/agent) via

--- a/agent-plane/agentplane-hashicorp/pom.xml
+++ b/agent-plane/agentplane-hashicorp/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.tractusx.agents.edc</groupId>
         <artifactId>agent-plane</artifactId>
-        <version>1.13.21-SNAPSHOT</version>
+        <version>1.13.22-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/agent-plane/agentplane-hashicorp/src/main/docker/Dockerfile
+++ b/agent-plane/agentplane-hashicorp/src/main/docker/Dockerfile
@@ -21,7 +21,7 @@ ENV OTEL_AGENT_LOCATION "https://github.com/open-telemetry/opentelemetry-java-in
 
 HEALTHCHECK NONE
 
-RUN apk update && apk add curl=8.5.0-r0 --no-cache
+RUN apk update && apk add curl=8.9.0-r0 --no-cache
 RUN curl -L --proto "=https" -sSf ${OTEL_AGENT_LOCATION} --output /tmp/opentelemetry-javaagent.jar
 
 FROM eclipse-temurin:22-jre-alpine

--- a/agent-plane/pom.xml
+++ b/agent-plane/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.eclipse.tractusx.agents</groupId>
         <artifactId>edc</artifactId>
-        <version>1.13.21-SNAPSHOT</version>
+        <version>1.13.22-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>    
     </parent>
     <name>Tractus-X EDC Agent Plane</name>

--- a/charts/agent-plane-azure-vault/Chart.yaml
+++ b/charts/agent-plane-azure-vault/Chart.yaml
@@ -41,12 +41,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.13.21-SNAPSHOT
+version: 1.13.22-SNAPSHOT
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.13.21-SNAPSHOT"
+appVersion: "1.13.22-SNAPSHOT"
 home: https://github.com/eclipse-tractusx/knowledge-agents-edc/
 sources:
   - https://github.com/eclipse-tractusx/knowledge-agents-edc/tree/main/charts/agent-connector

--- a/charts/agent-plane-azure-vault/README.md
+++ b/charts/agent-plane-azure-vault/README.md
@@ -21,7 +21,7 @@
 
 # agent-plane-azure-vault
 
-![Version: 1.13.21-SNAPSHOT](https://img.shields.io/badge/Version-1.13.21--SNAPSHOT-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.13.21-SNAPSHOT](https://img.shields.io/badge/AppVersion-1.13.21--SNAPSHOT-informational?style=flat-square)
+![Version: 1.13.22-SNAPSHOT](https://img.shields.io/badge/Version-1.13.22--SNAPSHOT-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.13.22-SNAPSHOT](https://img.shields.io/badge/AppVersion-1.13.22--SNAPSHOT-informational?style=flat-square)
 
 A Helm chart for an Agent-Enabled Tractus-X Data Plane which registers at a running
 Control Plane.
@@ -59,7 +59,7 @@ Combined, run this shell command to start the in-memory Tractus-X EDC runtime:
 
 ```shell
 helm repo add eclipse-tractusx https://eclipse-tractusx.github.io/charts/dev
-helm install my-release eclipse-tractusx/agent-plane --version 1.13.21-SNAPSHOT
+helm install my-release eclipse-tractusx/agent-plane --version 1.13.22-SNAPSHOT
 ```
 
 ## Maintainers
@@ -83,15 +83,17 @@ helm install my-release eclipse-tractusx/agent-plane --version 1.13.21-SNAPSHOT
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | [affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) to configure which nodes the pods can be scheduled on |
-| agent | object | `{"connectors":{},"default":["dataspace.ttl","https://w3id.org/catenax/ontology.ttl"],"maxbatchsize":"9223372036854775807","services":{"allow":"(edcs?://.*)|(https://query\\\\.wikidata\\\\.org/sparql)","asset":{"allow":"(edcs?://.*)","deny":"https?://.*"},"deny":"http://.*"},"skillcontract":"Contract?partner=Skill","synchronization":-1}` | Agent-Specific Settings |
+| agent | object | `{"connectors":{},"default":["dataspace.ttl","https://w3id.org/catenax/ontology.ttl"],"maxbatchsize":"9223372036854775807","services":{"allow":"(edcs?://.*)|(https://query\\\\.wikidata\\\\.org/sparql)","asset":{"allow":"(edcs?://.*)","deny":"https?://.*"},"connector":{"allow":"https://.*","deny":"http://.*"},"deny":"http://.*"},"skillcontract":"Contract?partner=Skill","synchronization":-1}` | Agent-Specific Settings |
 | agent.connectors | object | `{}` | A map of partner ids to remote connector IDS URLs to synchronize with |
 | agent.default | list | `["dataspace.ttl","https://w3id.org/catenax/ontology.ttl"]` | A list of local or remote graph descriptions to build the default meta-graph/federated data catalogue |
 | agent.maxbatchsize | string | `"9223372036854775807"` | Sets the maximal batch size when delegating to agents and services |
-| agent.services | object | `{"allow":"(edcs?://.*)|(https://query\\\\.wikidata\\\\.org/sparql)","asset":{"allow":"(edcs?://.*)","deny":"https?://.*"},"deny":"http://.*"}` | A set of configs for regulating outgoing service calls |
+| agent.services | object | `{"allow":"(edcs?://.*)|(https://query\\\\.wikidata\\\\.org/sparql)","asset":{"allow":"(edcs?://.*)","deny":"https?://.*"},"connector":{"allow":"https://.*","deny":"http://.*"},"deny":"http://.*"}` | A set of configs for regulating outgoing service calls |
 | agent.services.allow | string | `"(edcs?://.*)|(https://query\\\\.wikidata\\\\.org/sparql)"` | A regular expression which outgoing service URLs must match (unless overwritten by a specific asset property) |
 | agent.services.asset | object | `{"allow":"(edcs?://.*)","deny":"https?://.*"}` | A set of configs for regulating outgoing service calls when providing an asset (when no specific asset property is given) |
 | agent.services.asset.allow | string | `"(edcs?://.*)"` | A regular expression which outgoing service URLs must match (unless overwritten by a specific asset property) |
 | agent.services.asset.deny | string | `"https?://.*"` | A regular expression which outgoing service URLs must not match (unless overwritten by a specific asset property) |
+| agent.services.connector.allow | string | `"https://.*"` | A regular expression which outgoing connector URLs must match  |
+| agent.services.connector.deny | string | `"http://.*"` | A regular expression which outgoing connector URLs must not match |
 | agent.services.deny | string | `"http://.*"` | A regular expression which outgoing service URLs must not match (unless overwritten by a specific asset property) |
 | agent.skillcontract | string | `"Contract?partner=Skill"` | Names the visible contract under which new skills are published (if not otherwise specified) |
 | agent.synchronization | int | `-1` | The synchronization interval in ms to update the federated data catalogue |
@@ -244,4 +246,4 @@ helm install my-release eclipse-tractusx/agent-plane --version 1.13.21-SNAPSHOT
 | volumes | list | `[]` | [volume](https://kubernetes.io/docs/concepts/storage/volumes/) directories |
 
 ----------------------------------------------
-Autogenerated from chart metadata using [helm-docs v1.11.2](https://github.com/norwoodj/helm-docs/releases/v1.11.2)
+Autogenerated from chart metadata using [helm-docs v1.14.2](https://github.com/norwoodj/helm-docs/releases/v1.14.2)

--- a/charts/agent-plane-azure-vault/ci/integration-values.yaml
+++ b/charts/agent-plane-azure-vault/ci/integration-values.yaml
@@ -29,7 +29,7 @@ participant:
 
 # image:
 #  repository: ghcr.io/catenax-ng/tx-knowledge-agents-edc/agentplane-azure-vault
-#  tag: 1.13.21-SNAPSHOT
+#  tag: 1.13.22-SNAPSHOT
 
 controlplane:
   endpoints:

--- a/charts/agent-plane-azure-vault/values.yaml
+++ b/charts/agent-plane-azure-vault/values.yaml
@@ -408,6 +408,11 @@ agent:
       allow: '(edcs?://.*)'
       # -- A regular expression which outgoing service URLs must not match (unless overwritten by a specific asset property)
       deny: 'https?://.*'
+    connector:
+      # -- A regular expression which outgoing connector URLs must match 
+      allow: 'https://.*'
+      # -- A regular expression which outgoing connector URLs must not match
+      deny: 'http://.*'
 
 # -- Standard settings for persistence, "jdbcUrl", "username" and "password" need to be overridden
 postgresql:

--- a/charts/agent-plane-azure-vault/values.yaml
+++ b/charts/agent-plane-azure-vault/values.yaml
@@ -409,7 +409,7 @@ agent:
       # -- A regular expression which outgoing service URLs must not match (unless overwritten by a specific asset property)
       deny: 'https?://.*'
     connector:
-      # -- A regular expression which outgoing connector URLs must match 
+      # -- A regular expression which outgoing connector URLs must match
       allow: 'https://.*'
       # -- A regular expression which outgoing connector URLs must not match
       deny: 'http://.*'

--- a/charts/agent-plane/Chart.yaml
+++ b/charts/agent-plane/Chart.yaml
@@ -41,12 +41,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.13.21-SNAPSHOT
+version: 1.13.22-SNAPSHOT
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.13.21-SNAPSHOT"
+appVersion: "1.13.22-SNAPSHOT"
 home: https://github.com/eclipse-tractusx/knowledge-agents-edc/
 sources:
   - https://github.com/eclipse-tractusx/knowledge-agents-edc/tree/main/charts/agent-connector

--- a/charts/agent-plane/README.md
+++ b/charts/agent-plane/README.md
@@ -21,7 +21,7 @@
 
 # agent-plane
 
-![Version: 1.13.21-SNAPSHOT](https://img.shields.io/badge/Version-1.13.21--SNAPSHOT-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.13.21-SNAPSHOT](https://img.shields.io/badge/AppVersion-1.13.21--SNAPSHOT-informational?style=flat-square)
+![Version: 1.13.22-SNAPSHOT](https://img.shields.io/badge/Version-1.13.22--SNAPSHOT-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.13.22-SNAPSHOT](https://img.shields.io/badge/AppVersion-1.13.22--SNAPSHOT-informational?style=flat-square)
 
 A Helm chart for an Agent-Enabled Tractus-X Data Plane which registers at a running
 Control Plane.
@@ -59,7 +59,7 @@ Combined, run this shell command to start the in-memory Tractus-X EDC runtime:
 
 ```shell
 helm repo add eclipse-tractusx https://eclipse-tractusx.github.io/charts/dev
-helm install my-release eclipse-tractusx/agent-plane --version 1.13.21-SNAPSHOT
+helm install my-release eclipse-tractusx/agent-plane --version 1.13.22-SNAPSHOT
 ```
 
 ## Maintainers
@@ -84,15 +84,17 @@ helm install my-release eclipse-tractusx/agent-plane --version 1.13.21-SNAPSHOT
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | [affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) to configure which nodes the pods can be scheduled on |
-| agent | object | `{"connectors":{},"default":["dataspace.ttl","https://w3id.org/catenax/ontology.ttl"],"maxbatchsize":"9223372036854775807","services":{"allow":"(edcs?://.*)|(https://query\\\\.wikidata\\\\.org/sparql)","asset":{"allow":"(edcs?://.*)","deny":"https?://.*"},"deny":"http://.*"},"skillcontract":"Contract?partner=Skill","synchronization":-1}` | Agent-Specific Settings |
+| agent | object | `{"connectors":{},"default":["dataspace.ttl","https://w3id.org/catenax/ontology.ttl"],"maxbatchsize":"9223372036854775807","services":{"allow":"(edcs?://.*)|(https://query\\\\.wikidata\\\\.org/sparql)","asset":{"allow":"(edcs?://.*)","deny":"https?://.*"},"connector":{"allow":"https://.*","deny":"http://.*"},"deny":"http://.*"},"skillcontract":"Contract?partner=Skill","synchronization":-1}` | Agent-Specific Settings |
 | agent.connectors | object | `{}` | A map of partner ids to remote connector IDS URLs to synchronize with |
 | agent.default | list | `["dataspace.ttl","https://w3id.org/catenax/ontology.ttl"]` | A list of local or remote graph descriptions to build the default meta-graph/federated data catalogue |
 | agent.maxbatchsize | string | `"9223372036854775807"` | Sets the maximal batch size when delegating to agents and services |
-| agent.services | object | `{"allow":"(edcs?://.*)|(https://query\\\\.wikidata\\\\.org/sparql)","asset":{"allow":"(edcs?://.*)","deny":"https?://.*"},"deny":"http://.*"}` | A set of configs for regulating outgoing service calls |
+| agent.services | object | `{"allow":"(edcs?://.*)|(https://query\\\\.wikidata\\\\.org/sparql)","asset":{"allow":"(edcs?://.*)","deny":"https?://.*"},"connector":{"allow":"https://.*","deny":"http://.*"},"deny":"http://.*"}` | A set of configs for regulating outgoing service calls |
 | agent.services.allow | string | `"(edcs?://.*)|(https://query\\\\.wikidata\\\\.org/sparql)"` | A regular expression which outgoing service URLs must match (unless overwritten by a specific asset property) |
 | agent.services.asset | object | `{"allow":"(edcs?://.*)","deny":"https?://.*"}` | A set of configs for regulating outgoing service calls when providing an asset (when no specific asset property is given) |
 | agent.services.asset.allow | string | `"(edcs?://.*)"` | A regular expression which outgoing service URLs must match (unless overwritten by a specific asset property) |
 | agent.services.asset.deny | string | `"https?://.*"` | A regular expression which outgoing service URLs must not match (unless overwritten by a specific asset property) |
+| agent.services.connector.allow | string | `"https://.*"` | A regular expression which outgoing connector URLs must match  |
+| agent.services.connector.deny | string | `"http://.*"` | A regular expression which outgoing connector URLs must not match  |
 | agent.services.deny | string | `"http://.*"` | A regular expression which outgoing service URLs must not match (unless overwritten by a specific asset property) |
 | agent.skillcontract | string | `"Contract?partner=Skill"` | Names the visible contract under which new skills are published (if not otherwise specified) |
 | agent.synchronization | int | `-1` | The synchronization interval in ms to update the federated data catalogue |
@@ -250,4 +252,4 @@ helm install my-release eclipse-tractusx/agent-plane --version 1.13.21-SNAPSHOT
 | volumes | list | `[]` | [volume](https://kubernetes.io/docs/concepts/storage/volumes/) directories |
 
 ----------------------------------------------
-Autogenerated from chart metadata using [helm-docs v1.11.2](https://github.com/norwoodj/helm-docs/releases/v1.11.2)
+Autogenerated from chart metadata using [helm-docs v1.14.2](https://github.com/norwoodj/helm-docs/releases/v1.14.2)

--- a/charts/agent-plane/ci/integration-values.yaml
+++ b/charts/agent-plane/ci/integration-values.yaml
@@ -30,7 +30,7 @@ participant:
 
 # image:
 #  repository: ghcr.io/catenax-ng/tx-knowledge-agents-edc/agentplane-hashicorp
-#  tag: 1.13.21-SNAPSHOT
+#  tag: 1.13.22-SNAPSHOT
 
 controlplane:
   endpoints:

--- a/charts/agent-plane/values.yaml
+++ b/charts/agent-plane/values.yaml
@@ -413,6 +413,11 @@ agent:
       allow: '(edcs?://.*)'
       # -- A regular expression which outgoing service URLs must not match (unless overwritten by a specific asset property)
       deny: 'https?://.*'
+    connector:
+      # -- A regular expression which outgoing connector URLs must match 
+      allow: 'https://.*'
+      # -- A regular expression which outgoing connector URLs must not match 
+      deny: 'http://.*'
 
 # -- Standard settings for persistence, "jdbcUrl", "username" and "password" need to be overridden
 postgresql:

--- a/charts/agent-plane/values.yaml
+++ b/charts/agent-plane/values.yaml
@@ -414,9 +414,9 @@ agent:
       # -- A regular expression which outgoing service URLs must not match (unless overwritten by a specific asset property)
       deny: 'https?://.*'
     connector:
-      # -- A regular expression which outgoing connector URLs must match 
+      # -- A regular expression which outgoing connector URLs must match
       allow: 'https://.*'
-      # -- A regular expression which outgoing connector URLs must not match 
+      # -- A regular expression which outgoing connector URLs must not match
       deny: 'http://.*'
 
 # -- Standard settings for persistence, "jdbcUrl", "username" and "password" need to be overridden

--- a/common/README.md
+++ b/common/README.md
@@ -57,7 +57,7 @@ add the following dependency to your maven dependencies (gradle should work anal
         <dependency>
           <groupId>org.eclipse.tractusx.edc</groupId>
           <artifactId>auth-jwt</artifactId>
-          <version>1.13.21-SNAPSHOT</version>
+          <version>1.13.22-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/common/auth-jwt/README.md
+++ b/common/auth-jwt/README.md
@@ -37,7 +37,7 @@ Add the following dependency to your EDC artifact pom:
         <dependency>
             <groupId>org.eclipse.tractusx.agents.edc</groupId>
             <artifactId>auth-jwt</artifactId>
-            <version>1.13.21-SNAPSHOT</version>
+            <version>1.13.22-SNAPSHOT</version>
         </dependency>
 ```
 

--- a/common/auth-jwt/pom.xml
+++ b/common/auth-jwt/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.eclipse.tractusx.agents</groupId>
         <artifactId>edc</artifactId>
-        <version>1.13.21-SNAPSHOT</version>
+        <version>1.13.22-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -75,7 +75,7 @@ dependencies:
       alias: my-connector
     - name: agent-plane
       repository: https://eclipse-tractusx.github.io/charts/dev
-      version: 1.13.21-SNAPSHOT
+      version: 1.13.22-SNAPSHOT
       alias: my-agent
 ```
 
@@ -90,7 +90,7 @@ dependencies:
       alias: my-connector
     - name: agent-plane-azure-vault
       repository: https://eclipse-tractusx.github.io/charts/dev
-      version: 1.13.21-SNAPSHOT
+      version: 1.13.22-SNAPSHOT
       alias: my-agent
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.eclipse.tractusx.agents</groupId>
     <artifactId>edc</artifactId>
-    <version>1.13.21-SNAPSHOT</version>
+    <version>1.13.22-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Tractus-X Knowledge Agents EDC Extensions</name>
     <description>EDC-Related Artifacts for Federated Procedure Calls</description>

--- a/upgrade_version.sh
+++ b/upgrade_version.sh
@@ -16,7 +16,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-OLD_VERSION=1.13.21-SNAPSHOT
+OLD_VERSION=1.13.22-SNAPSHOT
 echo Upgrading from $OLD_VERSION to $1
 PATTERN=s/$OLD_VERSION/$1/g
 LC_ALL=C


### PR DESCRIPTION
<!--
 * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Apache License, Version 2.0 which is available at
 * https://www.apache.org/licenses/LICENSE-2.0.
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 * License for the specific language governing permissions and limitations
 * under the License.
 *
 * SPDX-License-Identifier: Apache-2.0
-->

## WHAT

- Extend helm chart values with a "connector" section that was already implemented/foreseen in the templates.
- Upgrade version.
- Debug the "update skill" logic
- Debug the Skill Provisioning Logic in AgentSource.

## WHY

This makes it possible to configure the agent planes to run against "internally networked" connectors over http instead of https.
It resolves a bug in the CONSUMER mode of skills which would allow to run on PROVIDER and - else - misses to parameterize the query string in the presence of a resultset body.
It resolves a bug in the skill creation API which was expecting an id`d-response from an EDC management PUT request (which usually is empty).

## FURTHER NOTES

Final release version is 1.13.22

Closes #228 <-- _insert Issue number if one exists_
