### PR TITLE
feature : TX 2412 upgrade (TX EDC 0.8.0 release)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,7 +101,7 @@ jobs:
 
       # Needed to create multi-platform image
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 (v3.7.1)
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 #(v3.7.1)
 
       # Enable deployment access (on demand or main branch and version tags only)
       - name: Login to GitHub Container Registry

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,7 +101,7 @@ jobs:
 
       # Needed to create multi-platform image
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 (v3.7.1)
 
       # Enable deployment access (on demand or main branch and version tags only)
       - name: Login to GitHub Container Registry

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,6 +99,10 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
 
+      # Needed to create multi-platform image
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       # Enable deployment access (on demand or main branch and version tags only)
       - name: Login to GitHub Container Registry
         if: ${{ ( github.event.inputs.deploy_docker == 'true' || github.ref == 'refs/heads/main' ||  startsWith(github.ref, 'refs/tags/v') ) }}
@@ -150,6 +154,8 @@ jobs:
         with:
           context: agent-plane/agentplane-hashicorp
           file: agent-plane/agentplane-hashicorp/src/main/docker/Dockerfile
+          # Needed to create multi-platform image
+          platforms: linux/amd64, linux/arm64
           # Build image for verification purposes on every trigger event. Only push if event is not a PR
           push: ${{ ( github.event.inputs.deploy_docker == 'true' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') ) }}
           tags: ${{ steps.meta-hash.outputs.tags }}
@@ -188,6 +194,8 @@ jobs:
         with:
           context: agent-plane/agentplane-azure-vault/.
           file: agent-plane/agentplane-azure-vault/src/main/docker/Dockerfile
+          # Needed to create multi-platform image
+          platforms: linux/amd64, linux/arm64
           # Build image for verification purposes on every trigger event. Only push if event is not a PR
           push: ${{ ( github.event.inputs.deploy_docker == 'true' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') ) }}
           tags: ${{ steps.meta-azr.outputs.tags }}

--- a/.github/workflows/helm-chart-lint.yml
+++ b/.github/workflows/helm-chart-lint.yml
@@ -112,6 +112,15 @@ jobs:
         if: github.event_name != 'pull_request' || env.CHART_CHANGED == 'true'
 
       # install the chart to the kind cluster and run helm test
+      # when in manual mode
+      - name: Run chart-testing (install)
+        run: |
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo add hashicorp https://helm.releases.hashicorp.com
+          ct install --all --config charts/config/chart-testing-config.yaml --helm-extra-set-args="--set=imageRegistry=kind-registry:5000/"
+        if: github.event_name == 'workflow_dispatch' && env.CHART_CHANGED != 'true'
+
+      # install the chart to the kind cluster and run helm test
       # define charts to test with the --charts parameter
       - name: Run chart-testing (install)
         run: |

--- a/.github/workflows/helm-chart-lint.yml
+++ b/.github/workflows/helm-chart-lint.yml
@@ -86,7 +86,7 @@ jobs:
         uses: helm/chart-testing-action@e6669bcd63d7cb57cb4380c33043eebe5d111992 # v2.6.1
 
       - name: Run chart-testing (lint)
-        run: ct lint --target-branch ${{ github.base_ref || github.ref_name }} --config charts/config/chart-testing-config.yaml
+        run: ct lint --all --target-branch ${{ github.base_ref || github.ref_name }} --config charts/config/chart-testing-config.yaml
 
       - name: Run chart-testing (list-changed)
         id: list-changed
@@ -110,15 +110,6 @@ jobs:
         run: |
           ./mvnw -s settings.xml deploy -Drepo=kind-registry:5000/tractusx/ -Dmaven.deploy.skip -DskipTests -Pwith-docker-image
         if: github.event_name != 'pull_request' || env.CHART_CHANGED == 'true'
-
-      # install the chart to the kind cluster and run helm test
-      # when in manual mode
-      - name: Run chart-testing (install)
-        run: |
-          helm repo add bitnami https://charts.bitnami.com/bitnami
-          helm repo add hashicorp https://helm.releases.hashicorp.com
-          ct install --all --config charts/config/chart-testing-config.yaml --helm-extra-set-args="--set=imageRegistry=kind-registry:5000/"
-        if: github.event_name == 'workflow_dispatch' && env.CHART_CHANGED != 'true'
 
       # install the chart to the kind cluster and run helm test
       # define charts to test with the --charts parameter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to this product will be documented in this file.
 ### Changed
 
 - Adapted to Tractus-X EDC 0.8.0
+- Multi-Platform Support
 
 ## [1.13.22] - 2024-07-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,14 @@ All notable changes to this product will be documented in this file.
 
 # Released
 
+## [1.14.24] - 2024-11-25
+
+### Added
+
+### Changed
+
+- Adapted to Tractus-X EDC 0.8.0
+
 ## [1.13.22] - 2024-07-29
 
 ### Added

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -306,7 +306,7 @@ maven/mavencentral/org.eclipse.tractusx.edc/tokenrefresh-handler/0.8.0, Apache-2
 maven/mavencentral/org.eclipse.tractusx.edc/tokenrefresh-spi/0.8.0, Apache-2.0, approved, automotive.tractusx
 maven/mavencentral/org.eclipse.tractusx.edc/tx-dcp-sts-dim/0.8.0, Apache-2.0, approved, automotive.tractusx
 maven/mavencentral/org.flywaydb/flyway-core/10.21.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.flywaydb/flyway-database-postgresql/10.21.0, , restricted, clearlydefined
+maven/mavencentral/org.flywaydb/flyway-database-postgresql/10.21.0, Apache-2.0, approved, #17433
 maven/mavencentral/org.glassfish.hk2.external/aopalliance-repackaged/3.0.6, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish
 maven/mavencentral/org.glassfish.hk2/hk2-api/3.0.6, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish
 maven/mavencentral/org.glassfish.hk2/hk2-locator/3.0.6, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -10,8 +10,8 @@ maven/mavencentral/com.azure/azure-core/1.52.0, MIT, approved, clearlydefined
 maven/mavencentral/com.azure/azure-identity/1.13.2, MIT, approved, clearlydefined
 maven/mavencentral/com.azure/azure-json/1.2.0, MIT, approved, clearlydefined
 maven/mavencentral/com.azure/azure-security-keyvault-secrets/4.8.5, MIT, approved, #13690
-maven/mavencentral/com.azure/azure-storage-blob/12.28.0, MIT, approved, clearlydefined
-maven/mavencentral/com.azure/azure-storage-common/12.27.0, MIT, approved, #16851
+maven/mavencentral/com.azure/azure-storage-blob/12.28.1, MIT, approved, clearlydefined
+maven/mavencentral/com.azure/azure-storage-common/12.27.1, MIT, approved, #16851
 maven/mavencentral/com.azure/azure-storage-internal-avro/12.13.0, MIT, approved, clearlydefined
 maven/mavencentral/com.azure/azure-xml/1.1.0, MIT, approved, clearlydefined
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.18.0, Apache-2.0, approved, #16364
@@ -35,7 +35,7 @@ maven/mavencentral/com.github.docker-java/docker-java-transport-zerodep/3.4.0, A
 maven/mavencentral/com.github.docker-java/docker-java-transport/3.4.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.github.jsonld-java/jsonld-java/0.13.4, BSD-3-Clause, approved, CQ22136
 maven/mavencentral/com.github.stephenc.jcip/jcip-annotations/1.0-1, Apache-2.0, approved, CQ21949
-maven/mavencentral/com.google.code.findbugs/jsr305/3.0.2, CC-BY-2.5, approved, #15220
+maven/mavencentral/com.google.code.findbugs/jsr305/3.0.2, Apache-2.0 and CC-BY-2.5, approved, #15220
 maven/mavencentral/com.google.code.gson/gson/2.10.1, Apache-2.0, approved, #6159
 maven/mavencentral/com.google.crypto.tink/tink/1.15.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.errorprone/error_prone_annotations/2.22.0, Apache-2.0, approved, #10661
@@ -111,7 +111,7 @@ maven/mavencentral/io.prometheus/simpleclient_tracer_common/0.16.0, Apache-2.0, 
 maven/mavencentral/io.prometheus/simpleclient_tracer_otel/0.16.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.prometheus/simpleclient_tracer_otel_agent/0.16.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.setl/rdf-urdna/1.1, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.swagger.core.v3/swagger-annotations-jakarta/2.2.24, Apache-2.0, approved, #5947
+maven/mavencentral/io.swagger.core.v3/swagger-annotations-jakarta/2.2.25, Apache-2.0, approved, #5947
 maven/mavencentral/io.swagger.core.v3/swagger-core-jakarta/2.2.22, Apache-2.0, approved, #5929
 maven/mavencentral/io.swagger.core.v3/swagger-integration-jakarta/2.2.22, Apache-2.0, approved, #11475
 maven/mavencentral/io.swagger.core.v3/swagger-jaxrs2-jakarta/2.2.22, Apache-2.0, approved, #11477
@@ -166,102 +166,105 @@ maven/mavencentral/org.bouncycastle/bcutil-jdk18on/1.78.1, MIT, approved, #14435
 maven/mavencentral/org.checkerframework/checker-qual/3.33.0, MIT, approved, clearlydefined
 maven/mavencentral/org.checkerframework/checker-qual/3.42.0, MIT, approved, clearlydefined
 maven/mavencentral/org.codehaus.woodstox/stax2-api/4.2.2, BSD-2-Clause, approved, #2670
-maven/mavencentral/org.eclipse.edc.aws/aws-s3-core/0.10.0-20241006-20241006.031648-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc.aws/aws-spi/0.10.0-20241006-20241006.031648-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc.aws/data-plane-aws-s3/0.10.0-20241006-20241006.031648-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc.aws/validator-data-address-s3/0.10.0-20241006-20241006.031648-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc.azure/azure-blob-core/0.10.0-20241006-20241006.031714-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc.azure/data-plane-azure-storage/0.10.0-20241006-20241006.031714-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc.azure/vault-azure/0.10.0-20241006-20241006.031714-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/accesstokendata-store-sql/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/api-core/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/api-observability/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/asset-spi/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/auth-spi/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/boot-lib/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/boot-spi/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/boot/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/catalog-spi/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/configuration-filesystem/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/connector-core/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/contract-spi/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/control-api-configuration/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/control-plane-api-client-spi/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/control-plane-api-client/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/core-spi/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/crypto-common-lib/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/data-address-http-data-spi/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/data-plane-core/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/data-plane-http-oauth2-core/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/data-plane-http-oauth2/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/data-plane-http-spi/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/data-plane-http/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/data-plane-iam/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/data-plane-public-api-v2/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/data-plane-selector-client/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/data-plane-selector-spi/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/data-plane-self-registration/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/data-plane-signaling-api/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/data-plane-signaling-transform/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/data-plane-spi/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/data-plane-store-sql/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/data-plane-util/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/edr-index-sql/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/edr-store-core/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/edr-store-spi/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/http-lib/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/http-spi/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/http/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/identity-did-core/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/identity-did-spi/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/identity-did-web/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/identity-trust-spi/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/identity-trust-sts-remote-lib/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/jersey-core/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/jersey-micrometer/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/jersey-providers-lib/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/jetty-core/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/jetty-micrometer/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/json-ld-lib/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/json-ld-spi/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/json-ld/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/json-lib/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/junit-base/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/junit/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/jwt-signer-spi/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/jwt-spi/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/keys-lib/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/keys-spi/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/micrometer-core/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/oauth2-client/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/oauth2-spi/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/policy-engine-lib/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/policy-engine-spi/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/policy-evaluator-lib/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/policy-model/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/policy-spi/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/query-lib/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/runtime-metamodel/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/sql-bootstrapper/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/sql-core/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/sql-lease/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/sql-pool-apache-commons/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/state-machine-lib/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/store-lib/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/token-core/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/token-spi/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/transaction-datasource-spi/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/transaction-local/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/transaction-spi/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/transfer-spi/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/transform-lib/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/transform-spi/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/util-lib/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/validator-lib/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/validator-spi/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/vault-hashicorp/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/verifiable-credentials-spi/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/web-spi/0.10.0-20241006-20241006.002751-1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc.aws/aws-s3-core/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc.aws/aws-spi/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc.aws/data-plane-aws-s3/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc.aws/validator-data-address-s3/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc.azure/azure-blob-core/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc.azure/data-plane-azure-storage/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc.azure/vault-azure/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/accesstokendata-store-sql/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/api-core/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/api-observability/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/asset-spi/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/auth-spi/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/boot-lib/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/boot-spi/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/boot/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/catalog-spi/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/configuration-filesystem/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/connector-core/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/contract-spi/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/control-api-configuration/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/control-plane-api-client-spi/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/control-plane-api-client/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/core-spi/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/crypto-common-lib/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/data-address-http-data-spi/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/data-plane-core/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/data-plane-http-oauth2-core/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/data-plane-http-oauth2/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/data-plane-http-spi/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/data-plane-http/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/data-plane-iam/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/data-plane-public-api-v2/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/data-plane-selector-client/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/data-plane-selector-spi/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/data-plane-self-registration/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/data-plane-signaling-api/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/data-plane-signaling-transform/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/data-plane-spi/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/data-plane-store-sql/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/data-plane-util/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/edr-index-sql/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/edr-store-core/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/edr-store-spi/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/http-lib/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/http-spi/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/http/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/identity-did-core/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/identity-did-spi/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/identity-did-web/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/identity-trust-spi/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/identity-trust-sts-remote-lib/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/jersey-core/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/jersey-micrometer/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/jersey-providers-lib/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/jetty-core/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/jetty-micrometer/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/json-ld-lib/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/json-ld-spi/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/json-ld/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/json-lib/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/junit-base/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/junit/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/jwt-signer-spi/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/jwt-spi/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/keys-lib/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/keys-spi/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/micrometer-core/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/oauth2-client/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/oauth2-spi/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/participant-spi/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/policy-engine-lib/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/policy-engine-spi/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/policy-evaluator-lib/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/policy-model/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/policy-spi/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/query-lib/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/request-policy-context-spi/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/runtime-metamodel/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/sql-bootstrapper/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/sql-core/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/sql-lease/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/sql-pool-apache-commons/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/state-machine-lib/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/store-lib/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/token-core/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/token-lib/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/token-spi/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/transaction-datasource-spi/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/transaction-local/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/transaction-spi/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/transfer-spi/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/transform-lib/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/transform-spi/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/util-lib/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/validator-lib/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/validator-spi/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/vault-hashicorp/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/verifiable-credentials-spi/0.10.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/web-spi/0.10.1, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.jetty.toolchain/jetty-jakarta-servlet-api/5.0.2, EPL-2.0 OR Apache-2.0, approved, rt.jetty
 maven/mavencentral/org.eclipse.jetty.toolchain/jetty-jakarta-websocket-api/2.0.0, EPL-2.0 OR Apache-2.0, approved, rt.jetty
 maven/mavencentral/org.eclipse.jetty.websocket/websocket-core-client/11.0.24, EPL-2.0 OR Apache-2.0, approved, rt.jetty
@@ -287,37 +290,37 @@ maven/mavencentral/org.eclipse.jetty/jetty-xml/11.0.24, EPL-2.0 OR Apache-2.0, a
 maven/mavencentral/org.eclipse.parsson/parsson/1.1.7, EPL-2.0, approved, ee4j.parsson
 maven/mavencentral/org.eclipse.tractusx.agents.edc.agent-plane/agent-plane-protocol/1.14.24-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
 maven/mavencentral/org.eclipse.tractusx.edc/auth-jwt/1.14.24-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.eclipse.tractusx.edc/core-spi/0.8.0-rc4, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.eclipse.tractusx.edc/core-utils/0.8.0-rc4, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.eclipse.tractusx.edc/data-plane-migration/0.8.0-rc4, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.eclipse.tractusx.edc/edc-dataplane-azure-vault/0.8.0-rc4, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.eclipse.tractusx.edc/edc-dataplane-base/0.8.0-rc4, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.eclipse.tractusx.edc/edc-dataplane-hashicorp-vault/0.8.0-rc4, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.eclipse.tractusx.edc/edc-dataplane-proxy-consumer-api/0.8.0-rc4, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.eclipse.tractusx.edc/edr-core/0.8.0-rc4, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.eclipse.tractusx.edc/edr-spi/0.8.0-rc4, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.eclipse.tractusx.edc/postgresql-migration-lib/0.8.0-rc4, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.eclipse.tractusx.edc/token-refresh-api/0.8.0-rc4, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.eclipse.tractusx.edc/token-refresh-core/0.8.0-rc4, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.eclipse.tractusx.edc/tokenrefresh-handler/0.8.0-rc4, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.eclipse.tractusx.edc/tokenrefresh-spi/0.8.0-rc4, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.eclipse.tractusx.edc/tx-dcp-sts-dim/0.8.0-rc4, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.flywaydb/flyway-core/10.18.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.flywaydb/flyway-database-postgresql/10.18.0, Apache-2.0, approved, #16801
+maven/mavencentral/org.eclipse.tractusx.edc/core-spi/0.8.0, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx.edc/core-utils/0.8.0, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx.edc/data-plane-migration/0.8.0, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx.edc/edc-dataplane-azure-vault/0.8.0, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx.edc/edc-dataplane-base/0.8.0, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx.edc/edc-dataplane-hashicorp-vault/0.8.0, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx.edc/edc-dataplane-proxy-consumer-api/0.8.0, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx.edc/edr-core/0.8.0, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx.edc/edr-spi/0.8.0, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx.edc/postgresql-migration-lib/0.8.0, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx.edc/token-refresh-api/0.8.0, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx.edc/token-refresh-core/0.8.0, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx.edc/tokenrefresh-handler/0.8.0, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx.edc/tokenrefresh-spi/0.8.0, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx.edc/tx-dcp-sts-dim/0.8.0, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.flywaydb/flyway-core/10.21.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.flywaydb/flyway-database-postgresql/10.21.0, , restricted, clearlydefined
 maven/mavencentral/org.glassfish.hk2.external/aopalliance-repackaged/3.0.6, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish
 maven/mavencentral/org.glassfish.hk2/hk2-api/3.0.6, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish
 maven/mavencentral/org.glassfish.hk2/hk2-locator/3.0.6, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish
 maven/mavencentral/org.glassfish.hk2/hk2-utils/3.0.6, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish
 maven/mavencentral/org.glassfish.hk2/osgi-resource-locator/1.0.3, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish
-maven/mavencentral/org.glassfish.jersey.containers/jersey-container-servlet-core/3.1.8, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
-maven/mavencentral/org.glassfish.jersey.containers/jersey-container-servlet/3.1.8, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
-maven/mavencentral/org.glassfish.jersey.core/jersey-client/3.1.8, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
-maven/mavencentral/org.glassfish.jersey.core/jersey-common/3.1.8, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
-maven/mavencentral/org.glassfish.jersey.core/jersey-server/3.1.8, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
-maven/mavencentral/org.glassfish.jersey.ext/jersey-entity-filtering/3.1.8, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
-maven/mavencentral/org.glassfish.jersey.inject/jersey-hk2/3.1.8, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
-maven/mavencentral/org.glassfish.jersey.media/jersey-media-json-jackson/3.1.8, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
-maven/mavencentral/org.glassfish.jersey.media/jersey-media-multipart/3.1.8, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.containers/jersey-container-servlet-core/3.1.9, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.containers/jersey-container-servlet/3.1.9, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.core/jersey-client/3.1.9, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.core/jersey-common/3.1.9, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.core/jersey-server/3.1.9, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.ext/jersey-entity-filtering/3.1.9, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.inject/jersey-hk2/3.1.9, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.media/jersey-media-json-jackson/3.1.9, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.media/jersey-media-multipart/3.1.9, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
 maven/mavencentral/org.glassfish/jakarta.json/2.0.1, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jsonp
 maven/mavencentral/org.hamcrest/hamcrest-core/1.3, BSD-2-Clause, approved, CQ11429
 maven/mavencentral/org.hdrhistogram/HdrHistogram/2.2.2, BSD-2-Clause AND CC0-1.0 AND CC0-1.0, approved, #14828
@@ -330,7 +333,7 @@ maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib-jdk8/1.9.10, Apache-2.0, a
 maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib/1.8.21, Apache-2.0, approved, #8865
 maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib/1.9.10, Apache-2.0, approved, #11827
 maven/mavencentral/org.jetbrains/annotations/13.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.jetbrains/annotations/25.0.0, Apache-2.0, approved, #16624
+maven/mavencentral/org.jetbrains/annotations/26.0.1, Apache-2.0, approved, #16629
 maven/mavencentral/org.junit.jupiter/junit-jupiter-api/5.11.0, EPL-2.0, approved, #15935
 maven/mavencentral/org.junit.jupiter/junit-jupiter-engine/5.11.0, EPL-2.0, approved, #15939
 maven/mavencentral/org.junit.platform/junit-platform-commons/1.11.0, EPL-2.0, approved, #15936
@@ -353,34 +356,34 @@ maven/mavencentral/org.testcontainers/junit-jupiter/1.20.2, MIT, approved, #1655
 maven/mavencentral/org.testcontainers/testcontainers/1.20.2, MIT, approved, #15747
 maven/mavencentral/org.yaml/snakeyaml/2.2, Apache-2.0 AND (Apache-2.0 OR BSD-3-Clause OR EPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later), approved, #10232
 maven/mavencentral/software.amazon.awssdk/annotations/2.26.7, Apache-2.0, approved, clearlydefined
-maven/mavencentral/software.amazon.awssdk/apache-client/2.26.27, Apache-2.0, approved, clearlydefined
-maven/mavencentral/software.amazon.awssdk/arns/2.26.27, Apache-2.0, approved, clearlydefined
-maven/mavencentral/software.amazon.awssdk/auth/2.26.27, Apache-2.0, approved, clearlydefined
-maven/mavencentral/software.amazon.awssdk/aws-core/2.26.27, Apache-2.0, approved, clearlydefined
-maven/mavencentral/software.amazon.awssdk/aws-query-protocol/2.26.27, Apache-2.0, approved, clearlydefined
-maven/mavencentral/software.amazon.awssdk/aws-xml-protocol/2.26.27, Apache-2.0, approved, clearlydefined
-maven/mavencentral/software.amazon.awssdk/checksums-spi/2.26.27, Apache-2.0, approved, clearlydefined
-maven/mavencentral/software.amazon.awssdk/checksums/2.26.27, Apache-2.0, approved, clearlydefined
-maven/mavencentral/software.amazon.awssdk/crt-core/2.26.27, Apache-2.0, approved, clearlydefined
-maven/mavencentral/software.amazon.awssdk/endpoints-spi/2.26.27, Apache-2.0, approved, clearlydefined
-maven/mavencentral/software.amazon.awssdk/http-auth-aws-eventstream/2.26.27, Apache-2.0, approved, clearlydefined
-maven/mavencentral/software.amazon.awssdk/http-auth-aws/2.26.27, Apache-2.0, approved, clearlydefined
-maven/mavencentral/software.amazon.awssdk/http-auth-spi/2.26.27, Apache-2.0, approved, clearlydefined
-maven/mavencentral/software.amazon.awssdk/http-auth/2.26.27, Apache-2.0, approved, clearlydefined
+maven/mavencentral/software.amazon.awssdk/apache-client/2.28.26, Apache-2.0, approved, #16533
+maven/mavencentral/software.amazon.awssdk/arns/2.28.26, Apache-2.0, approved, #16519
+maven/mavencentral/software.amazon.awssdk/auth/2.28.26, Apache-2.0, approved, #16541
+maven/mavencentral/software.amazon.awssdk/aws-core/2.28.26, Apache-2.0, approved, #16534
+maven/mavencentral/software.amazon.awssdk/aws-query-protocol/2.28.26, Apache-2.0, approved, #16507
+maven/mavencentral/software.amazon.awssdk/aws-xml-protocol/2.28.26, Apache-2.0, approved, #16502
+maven/mavencentral/software.amazon.awssdk/checksums-spi/2.28.26, Apache-2.0, approved, #16517
+maven/mavencentral/software.amazon.awssdk/checksums/2.28.26, Apache-2.0, approved, #16542
+maven/mavencentral/software.amazon.awssdk/crt-core/2.28.26, Apache-2.0, approved, #16512
+maven/mavencentral/software.amazon.awssdk/endpoints-spi/2.28.26, Apache-2.0, approved, #16509
+maven/mavencentral/software.amazon.awssdk/http-auth-aws-eventstream/2.28.26, Apache-2.0, approved, #16513
+maven/mavencentral/software.amazon.awssdk/http-auth-aws/2.28.26, Apache-2.0, approved, #16508
+maven/mavencentral/software.amazon.awssdk/http-auth-spi/2.28.26, Apache-2.0, approved, #16498
+maven/mavencentral/software.amazon.awssdk/http-auth/2.28.26, Apache-2.0, approved, #16511
 maven/mavencentral/software.amazon.awssdk/http-client-spi/2.26.7, Apache-2.0, approved, clearlydefined
-maven/mavencentral/software.amazon.awssdk/iam/2.26.27, Apache-2.0, approved, clearlydefined
-maven/mavencentral/software.amazon.awssdk/identity-spi/2.26.27, Apache-2.0, approved, clearlydefined
-maven/mavencentral/software.amazon.awssdk/json-utils/2.26.27, Apache-2.0, approved, clearlydefined
+maven/mavencentral/software.amazon.awssdk/iam/2.28.26, Apache-2.0, approved, #16684
+maven/mavencentral/software.amazon.awssdk/identity-spi/2.28.26, Apache-2.0, approved, #16544
+maven/mavencentral/software.amazon.awssdk/json-utils/2.28.26, Apache-2.0, approved, #16543
 maven/mavencentral/software.amazon.awssdk/metrics-spi/2.26.7, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/netty-nio-client/2.26.7, Apache-2.0, approved, clearlydefined
-maven/mavencentral/software.amazon.awssdk/profiles/2.26.27, Apache-2.0, approved, clearlydefined
-maven/mavencentral/software.amazon.awssdk/protocol-core/2.26.27, Apache-2.0, approved, clearlydefined
-maven/mavencentral/software.amazon.awssdk/regions/2.26.27, Apache-2.0, approved, clearlydefined
-maven/mavencentral/software.amazon.awssdk/retries-spi/2.26.27, Apache-2.0, approved, clearlydefined
-maven/mavencentral/software.amazon.awssdk/retries/2.26.27, Apache-2.0, approved, clearlydefined
-maven/mavencentral/software.amazon.awssdk/s3/2.26.27, Apache-2.0, approved, clearlydefined
-maven/mavencentral/software.amazon.awssdk/sdk-core/2.26.27, Apache-2.0, approved, #15695
-maven/mavencentral/software.amazon.awssdk/sts/2.26.27, Apache-2.0, approved, clearlydefined
-maven/mavencentral/software.amazon.awssdk/third-party-jackson-core/2.26.27, Apache-2.0, approved, #15693
+maven/mavencentral/software.amazon.awssdk/profiles/2.28.26, Apache-2.0, approved, #16520
+maven/mavencentral/software.amazon.awssdk/protocol-core/2.28.26, Apache-2.0, approved, #16521
+maven/mavencentral/software.amazon.awssdk/regions/2.28.26, Apache-2.0, approved, #16518
+maven/mavencentral/software.amazon.awssdk/retries-spi/2.28.26, Apache-2.0, approved, #16514
+maven/mavencentral/software.amazon.awssdk/retries/2.28.26, Apache-2.0, approved, #16495
+maven/mavencentral/software.amazon.awssdk/s3/2.28.26, Apache-2.0, approved, #16505
+maven/mavencentral/software.amazon.awssdk/sdk-core/2.28.26, Apache-2.0, approved, #16532
+maven/mavencentral/software.amazon.awssdk/sts/2.28.26, Apache-2.0, approved, #16685
+maven/mavencentral/software.amazon.awssdk/third-party-jackson-core/2.28.26, Apache-2.0, approved, #16500
 maven/mavencentral/software.amazon.awssdk/utils/2.26.7, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.eventstream/eventstream/1.0.1, Apache-2.0, approved, clearlydefined

--- a/agent-plane/agentplane-azure-vault/README.md
+++ b/agent-plane/agentplane-azure-vault/README.md
@@ -90,7 +90,7 @@ Project license: Apache License, Version 2.0
 
 **Used base image**
 
-- [eclipse-temurin:22-jre-alpine](https://github.com/adoptium/containers)
+- [eclipse-temurin:23-jre-alpine](https://github.com/adoptium/containers)
 - Official Eclipse Temurin DockerHub page: https://hub.docker.com/_/eclipse-temurin
 - Eclipse Temurin Project: https://projects.eclipse.org/projects/adoptium.temurin
 - Additional information about the Eclipse Temurin images: https://github.com/docker-library/repo-info/tree/master/repos/eclipse-temurin

--- a/agent-plane/agentplane-azure-vault/src/main/docker/Dockerfile
+++ b/agent-plane/agentplane-azure-vault/src/main/docker/Dockerfile
@@ -22,10 +22,10 @@ ENV OTEL_AGENT_LOCATION="https://github.com/open-telemetry/opentelemetry-java-in
 
 HEALTHCHECK NONE
 
-RUN apk update && apk add curl=8.10.1-r0 --no-cache
+RUN apk update && apk add curl=8.11.0-r2 --no-cache
 RUN curl -L --proto "=https" -sSf ${OTEL_AGENT_LOCATION} --output /tmp/opentelemetry-javaagent.jar
 
-FROM eclipse-temurin:22-jre-alpine
+FROM eclipse-temurin:23-jre-alpine
 
 ARG APP_USER=docker
 ARG APP_UID=10100

--- a/agent-plane/agentplane-hashicorp/README.md
+++ b/agent-plane/agentplane-hashicorp/README.md
@@ -90,7 +90,7 @@ Project license: Apache License, Version 2.0
 
 **Used base image**
 
-- [eclipse-temurin:22-jre-alpine](https://github.com/adoptium/containers)
+- [eclipse-temurin:23-jre-alpine](https://github.com/adoptium/containers)
 - Official Eclipse Temurin DockerHub page: https://hub.docker.com/_/eclipse-temurin
 - Eclipse Temurin Project: https://projects.eclipse.org/projects/adoptium.temurin
 - Additional information about the Eclipse Temurin images: https://github.com/docker-library/repo-info/tree/master/repos/eclipse-temurin

--- a/agent-plane/agentplane-hashicorp/src/main/docker/Dockerfile
+++ b/agent-plane/agentplane-hashicorp/src/main/docker/Dockerfile
@@ -21,10 +21,10 @@ ENV OTEL_AGENT_LOCATION="https://github.com/open-telemetry/opentelemetry-java-in
 
 HEALTHCHECK NONE
 
-RUN apk update && apk add curl=8.10.1-r0 --no-cache
+RUN apk update && apk add curl=8.11.0-r2 --no-cache
 RUN curl -L --proto "=https" -sSf ${OTEL_AGENT_LOCATION} --output /tmp/opentelemetry-javaagent.jar
 
-FROM eclipse-temurin:22-jre-alpine
+FROM eclipse-temurin:23-jre-alpine
 
 ARG APP_USER=docker
 ARG APP_UID=10100

--- a/pom.xml
+++ b/pom.xml
@@ -39,8 +39,8 @@
 
         <junit.version>5.11.0</junit.version>
         <mockito.version>5.2.0</mockito.version>
-        <tx.edc.version>0.8.0-rc4</tx.edc.version>
-        <edc.version>0.10.0-20241006-SNAPSHOT</edc.version>
+        <tx.edc.version>0.8.0</tx.edc.version>
+        <edc.version>0.10.1</edc.version>
         <org.apache.jena.version>4.9.0</org.apache.jena.version>
         <awssdk.version>2.26.7</awssdk.version>
         <com.azure.azure-identity.version>1.13.2</com.azure.azure-identity.version>


### PR DESCRIPTION
<!--
 * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Apache License, Version 2.0 which is available at
 * https://www.apache.org/licenses/LICENSE-2.0.
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 * License for the specific language governing permissions and limitations
 * under the License.
 *
 * SPDX-License-Identifier: Apache-2.0
-->

## WHAT

Adapts dependencies and base images to the TX EDC 0.8.0 release. 

## WHY

Provide the most possible compatibility of the agent planes.

## FURTHER NOTES

Closes #35 # <-- _insert Issue number if one exists_
